### PR TITLE
Implement InverseBlockDiagonalMatrix::clear()

### DIFF
--- a/sintering_impl.cc
+++ b/sintering_impl.cc
@@ -689,6 +689,13 @@ namespace Preconditioners
     }
 
     void
+    clear() override
+    {
+      blocks.clear();
+      weights.reinit(0);
+    }
+
+    void
     vmult(VectorType &dst, const VectorType &src) const override
     {
       dst = 0.0;


### PR DESCRIPTION
With element-block preconditioner (InverseBlockDiagonalMatrix, 1 process), I get the following numbers:

```
Final statistics:
  - n timesteps:               2505
  - n non-linear iterations:   19306
  - n linear iterations:       62956
  - avg non-linear iterations: 7.70699
  - avg linear iterations:     3.26096
  - max dt:                    1


+------------------------------+------------------+------------+------------------+
| Total wallclock time elapsed |     630.6s     0 |     630.6s |     630.6s     0 |
|                              |                  |                               |
| Section          | no. calls |   min time  rank |   avg time |   max time  rank |
+------------------------------+------------------+------------+------------------+
| time_loop        |         1 |     629.6s     0 |     629.6s |     629.6s     0 |
+------------------------------+------------------+------------+------------------+

+-------------------------------+------------------+------------+------------------+
| Total wallclock time elapsed  |     2.362s     0 |     2.362s |     2.362s     0 |
|                               |                  |                               |
| Section           | no. calls |   min time  rank |   avg time |   max time  rank |
+-------------------------------+------------------+------------+------------------+
| vmult_matrixbased |         1 |      1.14s     0 |      1.14s |      1.14s     0 |
| vmult_matrixfree  |         1 |      1.13s     0 |      1.13s |      1.13s     0 |
+-------------------------------+------------------+------------+------------------+
```

This looks promising and seems to be a reason look into more detail into element-block preconditioners. Let't see how the final system looks like! 

FYI @kronbichler 