### PR TITLE
Fix dynamic block vector

### DIFF
--- a/include/pf-applications/lac/dynamic_block_vector.h
+++ b/include/pf-applications/lac/dynamic_block_vector.h
@@ -41,6 +41,7 @@ namespace dealii
             {
               if (blocks[b] == nullptr)
                 blocks[b] = std::make_shared<BlockType>();
+              block(b).reinit(V.block(b), true);
               block(b) = V.block(b);
             }
 


### PR DESCRIPTION
Alternative to #85.

I haven't tried it out. But it seems to me that the `operator=` is the problem. The deal.II versions only update the locally owned values but do not update the partitioners if needed. @vovannikov Could you give this a try!? Btw.: have you run the code in debug mode? My guess would be that there should be an assert somewhere (in particular in MatrixFree/FEEvaluation - we have added there a couple in the last years, which should have been triggered!).