### PR TITLE
Apply constraints directly before solution transfer

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/driver.h
+++ b/applications/sintering/include/pf-applications/sintering/driver.h
@@ -374,11 +374,9 @@ namespace Sintering
         for (unsigned int b = 0; b < solution_dealii.n_blocks(); ++b)
           {
             solution_dealii.block(b).reinit(partitioner);
-
-            // note: we do not need to apply constraints, since they are
-            // are already set by the Newton solver
             solution_dealii.block(b).copy_locally_owned_data_from(
               solution.block(b));
+            constraint.distribute(solution_dealii.block(b));
           }
 
         solution_dealii.update_ghost_values();


### PR DESCRIPTION
@vovannikov I think this should fix the assert you encountered yesterday.

It is not needed to apply here constraints, since they already have been applied to the solution increments. But some rounding errors resulted in a situation that the constraints have been not fulfilled (accurately) anymore.