### PR TITLE
Parameter interface_buffer_ratio can be tuned via prm

### DIFF
--- a/applications/sintering/analysis_examples/default.prm
+++ b/applications/sintering/analysis_examples/default.prm
@@ -7,6 +7,7 @@ subsection Geometry
     set BoundaryFactor = 0.5
     set InterfaceWidth = 2.0
     set MinimizeOrderParameters = true
+    set InterfaceBufferRatio = 1.0
 end
 subsection Adaptivity
     set TopFractionOfCells = 0.3

--- a/applications/sintering/include/pf-applications/sintering/parameters.h
+++ b/applications/sintering/include/pf-applications/sintering/parameters.h
@@ -28,6 +28,7 @@ namespace Sintering
     double          boundary_factor        = 0.5;
     double          interface_width        = 2.0;
     bool            minimize_order_parameters = true;
+    double          interface_buffer_ratio    = 1.0;
     bool            periodic                  = false;
     bool            custom_bounding_box       = false;
     BoundingBoxData bounding_box_data;
@@ -178,6 +179,9 @@ namespace Sintering
       prm.add_parameter("MinimizeOrderParameters",
                         geometry_data.minimize_order_parameters,
                         "Minimize number of initial order parameters.");
+      prm.add_parameter("InterfaceBufferRatio",
+                        geometry_data.interface_buffer_ratio,
+                        "Interface buffer ratio.");
       prm.add_parameter("Periodic",
                         geometry_data.periodic,
                         "Is domain periodic.");

--- a/applications/sintering/sintering_cloud.cc
+++ b/applications/sintering/sintering_cloud.cc
@@ -80,17 +80,12 @@ main(int argc, char **argv)
 
   const auto particles = Sintering::read_particles<SINTERING_DIM>(fstream);
 
-  /* Additional buffer zone when computing distance for colorization. Defined as
-   * ratio of the interface width.
-   */
-  static constexpr double interface_buffer_ratio = 0.5;
-
   const auto initial_solution =
     std::make_shared<Sintering::InitialValuesCloud<SINTERING_DIM>>(
       particles,
       params.geometry_data.interface_width,
       params.geometry_data.minimize_order_parameters,
-      interface_buffer_ratio);
+      params.geometry_data.interface_buffer_ratio);
 
   AssertThrow(initial_solution->n_order_parameters() <= MAX_SINTERING_GRAINS,
               Sintering::ExcMaxGrainsExceeded(


### PR DESCRIPTION
The default value is too small, not safe enough. Moreover, it is nice to have a possibility to tune it.