### PR TITLE
Assign weights to cells

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/driver.h
+++ b/applications/sintering/include/pf-applications/sintering/driver.h
@@ -163,6 +163,14 @@ namespace Sintering
             }
         }
 
+      tria.signals.weight.connect(
+        [](const auto &cell_iterator, const auto cell_status) -> unsigned int {
+          (void)cell_iterator;
+          (void)cell_status;
+
+          return 1.0;
+        });
+
       create_mesh(tria,
                   boundaries.first,
                   boundaries.second,


### PR DESCRIPTION
references #110 

To reduce the load imbalance, we could add weights to the cells, which are used during re-partitioning. Currently, the weights do not have any meaning and we should replace it by something more useful once we know what influences the cost of a cell!