### PR TITLE
Enable AMG again

### DIFF
--- a/include/pf-applications/lac/preconditioners.h
+++ b/include/pf-applications/lac/preconditioners.h
@@ -479,6 +479,14 @@ namespace Preconditioners
         timer.print_wall_time_statistics(MPI_COMM_WORLD);
     }
 
+    virtual void
+    clear()
+    {
+      precondition_amg.clear();
+      src_.reinit(0);
+      dst_.reinit(0);
+    }
+
     void
     vmult(VectorType &dst, const VectorType &src) const override
     {


### PR DESCRIPTION
This PR allows (again) to use AMG on the AC block. 

I have run a quick comparision of preconditioners for the AC block. It looks like AMG and ILU lead to similar outer iterations (with AMG being somewhat slower). My hope is that a single V-cyle GMG leeds to similar number of outer iterations.

The raw output is below. Run with 40 processes and debug mode.

The program was executed via
```bash
mpirun -np 40 ./applications/sintering/sintering-circle-2D 2 2particles.prm
```
with the input file:
```
subsection Geometry
    set InterfaceWidth = 1.0
end
subsection TimeIntegration
    set TimeEnd = 1
end
subsection Preconditioners
    subsection BlockPreconditioner2
        set Block1Preconditioner = InverseDiagonalMatrix
    end
end
```

### InverseDiagonalMatrix

```
Final statistics:
  - n timesteps:               211
  - n non-linear iterations:   1093
  - n linear iterations:       9002
  - avg non-linear iterations: 5.18009
  - avg linear iterations:     8.23605
  - max dt:                    0.029672


+------------------------------+------------------+------------+------------------+
| Total wallclock time elapsed |      72.6s    30 |      72.6s |      72.6s    37 |
|                              |                  |                               |
| Section          | no. calls |   min time  rank |   avg time |   max time  rank |
+------------------------------+------------------+------------+------------------+
| time_loop        |         1 |     69.29s    17 |     69.29s |     69.29s    35 |
+------------------------------+------------------+------------+------------------+
```

### ILU

```
Final statistics:
  - n timesteps:               58
  - n non-linear iterations:   398
  - n linear iterations:       2996
  - avg non-linear iterations: 6.86207
  - avg linear iterations:     7.52764
  - max dt:                    0.0552061

+------------------------------+------------------+------------+------------------+
| Total wallclock time elapsed |     24.94s    33 |     24.94s |     24.94s    16 |
|                              |                  |                               |
| Section          | no. calls |   min time  rank |   avg time |   max time  rank |
+------------------------------+------------------+------------+------------------+
| time_loop        |         1 |     21.65s    25 |     21.65s |     21.65s    32 |
+------------------------------+------------------+------------+------------------+
```

### AMG

```
Final statistics:
  - n timesteps:               58
  - n non-linear iterations:   397
  - n linear iterations:       2982
  - avg non-linear iterations: 6.84483
  - avg linear iterations:     7.51134
  - max dt:                    0.0552061


+------------------------------+------------------+------------+------------------+
| Total wallclock time elapsed |     28.33s    24 |     28.33s |     28.33s     0 |
|                              |                  |                               |
| Section          | no. calls |   min time  rank |   avg time |   max time  rank |
+------------------------------+------------------+------------+------------------+
| time_loop        |         1 |     25.03s     2 |     25.03s |     25.03s    24 |
+------------------------------+------------------+------------+------------------+
```

@vovannikov  The experiments have to be repeated to a more realistic 3D case. Could you do that? One question in the 3D benchmark you have posted there a total of 8 components. I would have thought that we would have more (like 20-30). I am asking because it has some influence on how much work we have to invest on the CH block.