### PR TITLE
Make FE_Q_iso_Q1 available

### DIFF
--- a/applications/sintering/analysis_examples/49particles.json
+++ b/applications/sintering/analysis_examples/49particles.json
@@ -9,7 +9,8 @@
     },
     "Approximation": {
         "FEDegree": "1",
-        "NPoints1D": "2"
+        "NPoints1D": "2",
+        "NSubdivisions": "1"
     },
     "Energy": {
         "A": "16",

--- a/applications/sintering/include/pf-applications/sintering/parameters.h
+++ b/applications/sintering/include/pf-applications/sintering/parameters.h
@@ -8,8 +8,9 @@ namespace Sintering
 {
   struct ApproximationData
   {
-    unsigned int fe_degree   = 1;
-    unsigned int n_points_1D = 2;
+    unsigned int fe_degree      = 1;
+    unsigned int n_subdivisions = 1;
+    unsigned int n_points_1D    = 2;
   };
 
   struct BoundingBoxData
@@ -183,11 +184,36 @@ namespace Sintering
       prm.parse_input(file_name, "", true);
 
 #ifdef FE_DEGREE
-      AssertDimension(FE_DEGREE, approximation_data.fe_degree);
+      if (approximation_data.n_subdivisions == 1)
+        {
+          AssertThrow(FE_DEGREE == approximation_data.fe_degree,
+                      StandardExceptions::ExcDimensionMismatch(
+                        FE_DEGREE, approximation_data.fe_degree));
+        }
+      else
+        {
+          AssertThrow(FE_DEGREE == approximation_data.n_subdivisions,
+                      StandardExceptions::ExcDimensionMismatch(
+                        FE_DEGREE, approximation_data.n_subdivisions + 1));
+        }
 #endif
 
 #ifdef N_Q_POINTS_1D
-      AssertDimension(N_Q_POINTS_1D, approximation_data.n_points_1D);
+      if (approximation_data.n_subdivisions == 1)
+        {
+          AssertThrow(N_Q_POINTS_1D == approximation_data.n_points_1D,
+                      StandardExceptions::ExcDimensionMismatch(
+                        N_Q_POINTS_1D, approximation_data.n_points_1D));
+        }
+      else
+        {
+          AssertThrow(N_Q_POINTS_1D == approximation_data.n_points_1D *
+                                         approximation_data.n_subdivisions,
+                      StandardExceptions::ExcDimensionMismatch(
+                        N_Q_POINTS_1D,
+                        approximation_data.n_points_1D *
+                          approximation_data.n_subdivisions));
+        }
 #endif
     }
 
@@ -219,6 +245,9 @@ namespace Sintering
       prm.add_parameter("FEDegree",
                         approximation_data.fe_degree,
                         "Degree of the shape the finite element.");
+      prm.add_parameter("NSubdivisions",
+                        approximation_data.n_subdivisions,
+                        "Number of subdivisions.");
       prm.add_parameter("NPoints1D",
                         approximation_data.n_points_1D,
                         "Number of quadrature points.");

--- a/applications/sintering/sintering.cc
+++ b/applications/sintering/sintering.cc
@@ -23,8 +23,15 @@ static_assert(false, "No dimension has been given!");
 static_assert(false, "No grains number has been given!");
 #endif
 
-#define FE_DEGREE 1
-#define N_Q_POINTS_1D FE_DEGREE + 1
+//#define USE_FE_Q_iso_Q1
+
+#ifdef USE_FE_Q_iso_Q1
+#  define FE_DEGREE 2
+#  define N_Q_POINTS_1D FE_DEGREE * 2
+#else
+#  define FE_DEGREE 1
+#  define N_Q_POINTS_1D FE_DEGREE + 1
+#endif
 
 #define WITH_TIMING
 //#define WITH_TIMING_OUTPUT


### PR DESCRIPTION
In `adaflo` and `MeltPoolDG` (@mschreter ), we are using `FE_Q_iso_Q1` instead of `FE_Q(1)` to make matrix-free evaluations more efficient. We might want to consider it here as well.

Points to do:
- [ ] specialize sparsity pattern -> https://github.com/kronbichler/adaflo/blob/b65df326c695df5954a18533164bf046d0603997/source/level_set_okz_preconditioner.cc#L74-L115
- [ ] adjust refinement criterion so that it does less refinement steps, considering that `n_subdivisions` means implicitly already 1 refinement


I'll do the first one, in a follow-up PR. @vovannikov Could you (or we both together) do the second one?

FYI @kronbichler 