### PR TITLE
Write to the output git versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,16 @@ ENDIF()
 
 DEAL_II_INITIALIZE_CACHED_VARIABLES()
 
+DEAL_II_QUERY_GIT_INFORMATION(PF_APPLICATIONS)
+
+SET(HYPER_DEAL_GIT_BRANCH "@HYPER_DEAL_GIT_BRANCH@")
+SET(HYPER_DEAL_GIT_REVISION "@HYPER_DEAL_GIT_REVISION@")
+
+CONFIGURE_FILE(
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/pf-applications/base/revision.h.in
+  ${CMAKE_CURRENT_BINARY_DIR}/include/pf-applications/base/revision.h
+  )
+
 SET( TARGET_SRC dummy.cc)
 
 PROJECT(pf-applications)
@@ -44,7 +54,7 @@ DEAL_II_INITIALIZE_CACHED_VARIABLES()
 
 DEAL_II_SETUP_TARGET(pf-applications)
 
-target_include_directories(pf-applications PUBLIC "include/")
+target_include_directories(pf-applications PUBLIC "include/" ${CMAKE_CURRENT_BINARY_DIR}/include)
 
 FILE(GLOB SOURCE_FILES "*.cc")
 

--- a/applications/sintering/sintering.cc
+++ b/applications/sintering/sintering.cc
@@ -36,6 +36,10 @@ static_assert(false, "No grains number has been given!");
 #define WITH_TIMING
 //#define WITH_TIMING_OUTPUT
 
+#include <deal.II/base/revision.h>
+
+#include <pf-applications/base/revision.h>
+
 #include <pf-applications/sintering/driver.h>
 #include <pf-applications/sintering/initial_values_circle.h>
 #include <pf-applications/sintering/initial_values_cloud.h>
@@ -44,10 +48,35 @@ static_assert(false, "No grains number has been given!");
 
 using namespace dealii;
 
+std::string
+concatenate_strings(const int argc, char **argv)
+{
+  std::string result = std::string(argv[0]);
+
+  for (int i = 0; i < argc; ++i)
+    result = result + " " + std::string(argv[i]);
+
+  return result;
+}
+
 int
 main(int argc, char **argv)
 {
   Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv, 1);
+
+  ConditionalOStream pcout(std::cout,
+                           Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) ==
+                             0);
+
+  pcout << "Running: " << concatenate_strings(argc, argv) << std::endl;
+  pcout << "  - deal.II (branch: " << DEAL_II_GIT_BRANCH
+        << "; revision: " << DEAL_II_GIT_REVISION
+        << "; short: " << DEAL_II_GIT_SHORTREV << ")" << std::endl;
+  pcout << "  - deal.II (branch: " << PF_APPLICATIONS_GIT_BRANCH
+        << "; revision: " << PF_APPLICATIONS_GIT_REVISION
+        << "; short: " << PF_APPLICATIONS_GIT_SHORTREV << ")" << std::endl;
+  pcout << std::endl;
+  pcout << std::endl;
 
   Sintering::Parameters params;
 

--- a/include/pf-applications/base/revision.h.in
+++ b/include/pf-applications/base/revision.h.in
@@ -1,0 +1,16 @@
+#pragma once
+
+/**
+ * Name of the local git branch of the source directory.
+ */
+#define PF_APPLICATIONS_GIT_BRANCH "@PF_APPLICATIONS_GIT_BRANCH@"
+
+/**
+ * Full sha1 revision of the current git HEAD.
+ */
+#define PF_APPLICATIONS_GIT_REVISION "@PF_APPLICATIONS_GIT_REVISION@"
+
+/**
+ * Short sha1 revision of the current git HEAD.
+ */
+#define PF_APPLICATIONS_GIT_SHORTREV "@PF_APPLICATIONS_GIT_SHORTREV@"


### PR DESCRIPTION
motivated by the comment https://github.com/peterrum/pf-applications/pull/204#issuecomment-1221264233

We should also output the parameter files and the list of particles to make everything reproducible. @vovannikov Could take this task take on?

See also: https://github.com/dealii/dealii/pull/14204

@mschreter Are we somewhere monitoring the version of deal.II/MeltPoolDG?