### PR TITLE
Add new linear solvers

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/driver.h
+++ b/applications/sintering/include/pf-applications/sintering/driver.h
@@ -882,7 +882,7 @@ namespace Sintering
 
       std::unique_ptr<LinearSolvers::LinearSolverBase<Number>> linear_solver;
 
-      if (true)
+      if (params.nonlinear_data.l_solver == "GMRES")
         linear_solver = std::make_unique<LinearSolvers::SolverGMRESWrapper<
           NonLinearOperator,
           Preconditioners::PreconditionerBase<Number>>>(
@@ -890,6 +890,20 @@ namespace Sintering
           *preconditioner,
           solver_control_l,
           params.nonlinear_data.gmres_data);
+      else if (params.nonlinear_data.l_solver == "IDR")
+        linear_solver = std::make_unique<LinearSolvers::SolverIDRWrapper<
+          NonLinearOperator,
+          Preconditioners::PreconditionerBase<Number>>>(nonlinear_operator,
+                                                        *preconditioner,
+                                                        solver_control_l);
+      else if (params.nonlinear_data.l_solver == "Bicgstab")
+        linear_solver = std::make_unique<LinearSolvers::SolverBicgstabWrapper<
+          NonLinearOperator,
+          Preconditioners::PreconditionerBase<Number>>>(
+          nonlinear_operator,
+          *preconditioner,
+          solver_control_l,
+          params.nonlinear_data.l_bisgstab_tries);
 
       MyTimerOutput timer;
       TimerCollection::configure(params.profiling_data.output_time_interval);

--- a/applications/sintering/include/pf-applications/sintering/parameters.h
+++ b/applications/sintering/include/pf-applications/sintering/parameters.h
@@ -233,9 +233,11 @@ namespace Sintering
     double nl_abs_tol  = 1.e-20;
     double nl_rel_tol  = 1.e-5;
 
-    int    l_max_iter = 1000;
-    double l_abs_tol  = 1.e-10;
-    double l_rel_tol  = 1.e-2;
+    int          l_max_iter       = 1000;
+    double       l_abs_tol        = 1.e-10;
+    double       l_rel_tol        = 1.e-2;
+    std::string  l_solver         = "GMRES";
+    unsigned int l_bisgstab_tries = 30;
 
     bool         newton_do_update             = true;
     unsigned int newton_threshold_newton_iter = 100;
@@ -726,6 +728,14 @@ namespace Sintering
       prm.add_parameter("LinearAbsoluteTolerance", nonlinear_data.l_abs_tol);
       prm.add_parameter("LinearRelativeTolerance", nonlinear_data.l_rel_tol);
       prm.add_parameter("NewtonDoUpdate", nonlinear_data.newton_do_update);
+      prm.add_parameter("LinearSolver",
+                        nonlinear_data.l_solver,
+                        "Name of linear solver.",
+                        Patterns::Selection("GMRES|IDR|Bicgstab"));
+      prm.add_parameter("LinearSolver",
+                        nonlinear_data.l_bisgstab_tries,
+                        "Number of Bicgstab before switching to GMRES.");
+
       prm.add_parameter("NewtonThresholdNewtonIterations",
                         nonlinear_data.newton_threshold_newton_iter);
       prm.add_parameter("NewtonThresholdLinearIterations",

--- a/include/pf-applications/lac/dynamic_block_vector.h
+++ b/include/pf-applications/lac/dynamic_block_vector.h
@@ -372,6 +372,14 @@ namespace dealii
           return MyMemoryConsumption::memory_consumption(blocks);
         }
 
+        void
+        swap(DynamicBlockVector &V)
+        {
+          std::swap(this->block_counter, V.block_counter);
+          std::swap(this->blocks, V.blocks);
+          std::swap(this->size_, V.size_);
+        }
+
       private:
         unsigned int                            block_counter;
         std::vector<std::shared_ptr<BlockType>> blocks;

--- a/include/pf-applications/lac/solvers_linear.h
+++ b/include/pf-applications/lac/solvers_linear.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <deal.II/lac/solver_bicgstab.h>
 #include <deal.II/lac/solver_control.h>
 #include <deal.II/lac/solver_gmres.h>
+#include <deal.II/lac/solver_idr.h>
 
 #include <pf-applications/base/timer.h>
 
@@ -52,44 +54,37 @@ namespace LinearSolvers
     unsigned int
     solve(VectorType &dst, const VectorType &src) override
     {
-      MyScope scope(timer, "gmres::solve");
-
-      typename SolverGMRES<VectorType>::AdditionalData additional_data;
-      fill_additional_data(additional_data);
-
-      SolverGMRES<VectorType> solver(solver_control, additional_data);
-      solver.solve(op, dst, src, preconditioner);
-
-      return solver_control.last_step();
+      return solve_internal(dst, src);
     }
 
     unsigned int
     solve(BlockVectorType &dst, const BlockVectorType &src) override
     {
-      MyScope scope(timer, "gmres::solve");
-
-      typename SolverGMRES<BlockVectorType>::AdditionalData additional_data;
-      fill_additional_data(additional_data);
-
-      SolverGMRES<BlockVectorType> solver(solver_control, additional_data);
-      solver.solve(op, dst, src, preconditioner);
-
-      return solver_control.last_step();
+      return solve_internal(dst, src);
     }
 
   private:
-    template <typename AdditionalData>
-    void
-    fill_additional_data(AdditionalData &additional_data) const
+    template <typename T>
+    unsigned int
+    solve_internal(T &dst, const T &src)
     {
+      MyScope scope(timer, "gmres::solve");
+
+      typename SolverGMRES<T>::AdditionalData additional_data;
+
       if (data.orthogonalization_strategy == "classical gram schmidt")
-        additional_data.orthogonalization_strategy =
-          AdditionalData::OrthogonalizationStrategy::classical_gram_schmidt;
+        additional_data.orthogonalization_strategy = SolverGMRES<
+          T>::AdditionalData::OrthogonalizationStrategy::classical_gram_schmidt;
       else if (data.orthogonalization_strategy == "modified gram schmidt")
-        additional_data.orthogonalization_strategy =
-          AdditionalData::OrthogonalizationStrategy::modified_gram_schmidt;
+        additional_data.orthogonalization_strategy = SolverGMRES<
+          T>::AdditionalData::OrthogonalizationStrategy::modified_gram_schmidt;
       else
         AssertThrow(false, ExcNotImplemented());
+
+      SolverGMRES<T> solver(solver_control, additional_data);
+      solver.solve(op, dst, src, preconditioner);
+
+      return solver_control.last_step();
     }
 
     const Operator &op;
@@ -99,4 +94,136 @@ namespace LinearSolvers
 
     mutable MyTimerOutput timer;
   };
+
+
+
+  template <typename Operator, typename Preconditioner>
+  class SolverIDRWrapper
+    : public LinearSolverBase<typename Operator::value_type>
+  {
+  public:
+    using VectorType      = typename Operator::vector_type;
+    using BlockVectorType = typename Operator::BlockVectorType;
+
+    SolverIDRWrapper(const Operator &op,
+                     Preconditioner &preconditioner,
+                     SolverControl & solver_control)
+      : op(op)
+      , preconditioner(preconditioner)
+      , solver_control(solver_control)
+    {}
+
+    unsigned int
+    solve(VectorType &dst, const VectorType &src) override
+    {
+      return solve_internal(dst, src);
+    }
+
+    unsigned int
+    solve(BlockVectorType &dst, const BlockVectorType &src) override
+    {
+      return solve_internal(dst, src);
+    }
+
+  private:
+    template <typename T>
+    unsigned int
+    solve_internal(T &dst, const T &src)
+    {
+      MyScope scope(timer, "idr::solve");
+
+      SolverIDR<T> solver(solver_control);
+      solver.solve(op, dst, src, preconditioner);
+
+      return solver_control.last_step();
+    }
+
+    const Operator &op;
+    Preconditioner &preconditioner;
+    SolverControl & solver_control;
+
+    mutable MyTimerOutput timer;
+  };
+
+
+
+  template <typename Operator, typename Preconditioner>
+  class SolverBicgstabWrapper
+    : public LinearSolverBase<typename Operator::value_type>
+  {
+  public:
+    using VectorType      = typename Operator::vector_type;
+    using BlockVectorType = typename Operator::BlockVectorType;
+
+    SolverBicgstabWrapper(const Operator &   op,
+                          Preconditioner &   preconditioner,
+                          SolverControl &    solver_control,
+                          const unsigned int max_bicgsteps)
+      : op(op)
+      , preconditioner(preconditioner)
+      , solver_control(solver_control)
+      , max_bicgsteps(max_bicgsteps)
+    {}
+
+    unsigned int
+    solve(VectorType &dst, const VectorType &src) override
+    {
+      return solve_internal(dst, src);
+    }
+
+    unsigned int
+    solve(BlockVectorType &dst, const BlockVectorType &src) override
+    {
+      return solve_internal(dst, src);
+    }
+
+  private:
+    template <typename T>
+    unsigned int
+    solve_internal(T &dst, const T &src)
+    {
+      MyScope scope(timer, "bicgstab::solve");
+
+      // copy information to be able to restart with GMRESs
+      const unsigned int max_steps = solver_control.max_steps();
+
+      T dst_copy;
+      dst_copy.reinit(dst);
+      dst_copy.copy_locally_owned_data_from(dst);
+
+      try
+        {
+          // try to solve with Bicgstab with a reasonable number
+          // of iterations
+          solver_control.set_max_steps(max_bicgsteps);
+
+          SolverBicgstab<T> solver(solver_control);
+          solver.solve(op, dst, src, preconditioner);
+
+          solver_control.set_max_steps(max_steps);
+
+          return solver_control.last_step();
+        }
+      catch (const SolverControl::NoConvergence &)
+        {
+          // reset data
+          solver_control.set_max_steps(max_steps);
+          dst.copy_locally_owned_data_from(dst_copy);
+
+          // solve with GMRES
+          SolverGMRES<T> solver(solver_control);
+          solver.solve(op, dst, src, preconditioner);
+
+          return solver_control.last_step() + max_bicgsteps;
+        }
+    }
+
+    const Operator &   op;
+    Preconditioner &   preconditioner;
+    SolverControl &    solver_control;
+    const unsigned int max_bicgsteps;
+
+    mutable MyTimerOutput timer;
+  };
+
 } // namespace LinearSolvers


### PR DESCRIPTION
As noted in https://github.com/peterrum/pf-applications/issues/203#issuecomment-1216484270, we are spending about 50% of the time of the linear solver in the vector updates of GMRES. Let's try out some alternative implementations, which do not have quadratic complexity but might need more iterations. @kronbichler suggested to start with IDR and Bicgstab. Alternatively, we might also want to optimize the GMRES implementation of deal.II.

~depends on https://github.com/dealii/dealii/pull/14232~