### PR TITLE
Allow empty contacts in clouds

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/initial_values_cloud.h
+++ b/applications/sintering/include/pf-applications/sintering/initial_values_cloud.h
@@ -172,10 +172,6 @@ namespace Sintering
             }
         }
 
-      AssertThrow(contacts.empty() == false,
-                  ExcMessage(
-                    "No particles in contact, check the packing geometry!"));
-
       // Build colorization if compressed
       if (minimize_order_parameters)
         {

--- a/applications/sintering/sintering.cc
+++ b/applications/sintering/sintering.cc
@@ -245,6 +245,10 @@ main(int argc, char **argv)
           params.geometry_data.minimize_order_parameters,
           params.geometry_data.interface_buffer_ratio);
 
+      AssertThrow(initial_solution->n_contacts() > 0,
+                  ExcMessage(
+                    "No particles in contact, check the packing geometry!"));
+
       AssertThrow(
         initial_solution->n_order_parameters() <= MAX_SINTERING_GRAINS,
         Sintering::ExcMaxGrainsExceeded(initial_solution->n_order_parameters(),


### PR DESCRIPTION
Otherwise test `grain_tracker_periodic_corner` crashes.