### PR TITLE
Make Wang-like force to work like in creep

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/operator_sintering_coupled_wang.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_sintering_coupled_wang.h
@@ -257,6 +257,7 @@ namespace Sintering
       const auto &kappa_p     = this->data.kappa_p;
       const auto &order       = this->data.time_data.get_order();
       const auto &L           = mobility.Lgb();
+      const auto  dt          = this->data.time_data.get_current_dt();
       const auto  inv_dt      = 1. / this->data.time_data.get_current_dt();
 
       const auto old_solutions = this->history.get_old_solutions();
@@ -343,9 +344,12 @@ namespace Sintering
                           const auto &velocity = this->advection.get_velocity(
                             ig, phi.quadrature_point(q));
 
+                          // The force works as like in the case of creep
+                          const auto force = velocity * dt;
+
                           // Apply Wang velocity as body force
                           for (unsigned int d = 0; d < dim; ++d)
-                            value_result[n_grains + 2 + d] -= velocity[d];
+                            value_result[n_grains + 2 + d] -= force[d];
                         }
                     }
                 }


### PR DESCRIPTION
The previos expression turned out to be dependent on the time step size which is not desirable, the updated formula does not have this issue.

Old force:
![image](https://user-images.githubusercontent.com/8836201/208613581-a8059805-4c82-469b-af46-4e4b41052e3e.png)

New force:
![image](https://user-images.githubusercontent.com/8836201/208613713-7c66161c-4ad3-402b-a899-6c8cfae5e99b.png)
