### PR TITLE
Remove grain neighbors

### DIFF
--- a/include/pf-applications/grain_tracker/tracker.h
+++ b/include/pf-applications/grain_tracker/tracker.h
@@ -1252,7 +1252,7 @@ namespace GrainTracker
                    gr_base.get_old_order_parameter_id() ==
                      gr_other.get_old_order_parameter_id()))
                 {
-                  gr_base.add_neighbor(&gr_other);
+                  gr_base.add_neighbor(gr_other);
                 }
             }
         }


### PR DESCRIPTION
Keep only the relevant information on the distance to the nearest neighbor.

This fixes the first error in #301.