### PR TITLE
Add assert when a single grain is left in the domain

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/operator_base.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_base.h
@@ -54,7 +54,7 @@ constexpr bool has_n_grains_method =
         {                                                                                                             \
           case  1:                                                                                                    \
             AssertThrow(n_grains > 1,                                                                                 \
-              ExcMessage("A single grain is in the domain, sintering analysis is irrelevant, solution terminated.")); \
+              ExcMessage("A single grain case could not be compiled due to code restrictions."));                     \
           case  2: OPERATION(T::n_grains_to_n_components(std::min(max_grains,  2)), std::min(max_grains,  2)); break; \
           case  3: OPERATION(T::n_grains_to_n_components(std::min(max_grains,  3)), std::min(max_grains,  3)); break; \
           case  4: OPERATION(T::n_grains_to_n_components(std::min(max_grains,  4)), std::min(max_grains,  4)); break; \


### PR DESCRIPTION
@peterrum, you also mentioned during the call that you observed a crash somewhere from this place. When a single grain is remaining in the domain, that happens around 400 seconds for the 5 particles case, the error is raised. I've made it mode readable.