### PR TITLE
Add settings optimized for 5 particles

### DIFF
--- a/applications/sintering/analysis_examples/5particles.json
+++ b/applications/sintering/analysis_examples/5particles.json
@@ -58,7 +58,7 @@
         "NonLinearSolverType" : "NOX"
     },
     "Output": {
-        "Contour": "true",
+        "Contour": "false",
         "ContourNCoarseningSteps": "0",
         "Debug": "false",
         "Fields": "bnds",


### PR DESCRIPTION
These are optimized since those for 49 particles do not fit. The essential differences:
```
    "Output": {
        "OutputTimeInterval": "10",
        "Regular": "true",
        "Contour": "false",
    },
    
    "GrainTracker": {
        "GrainTrackerFrequency": "10",
    },
```

Grain tracker and AMR has to be invoked more oftened for this case. The regular 2D VTK output makes more sense for 2D than the contour plots.