### PR TITLE
Inline functions

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/tools.h
+++ b/applications/sintering/include/pf-applications/sintering/tools.h
@@ -317,14 +317,14 @@ namespace Sintering
                 const Tensor<1, dim, Number> &b);
 
   template <typename Number>
-  moment_t<2, Number>
+  DEAL_II_ALWAYS_INLINE inline moment_t<2, Number>
   cross_product(const Tensor<1, 2, Number> &a, const Tensor<1, 2, Number> &b)
   {
     return a[1] * b[0] - a[0] * b[1];
   }
 
   template <int dim, typename Number>
-  auto
+  DEAL_II_ALWAYS_INLINE inline auto
   create_moment_from_buffer(const Number *buffer)
   {
     if constexpr (dim == 3)
@@ -334,14 +334,14 @@ namespace Sintering
   }
 
   template <typename Number>
-  Tensor<1, 3, Number>
+  DEAL_II_ALWAYS_INLINE inline Tensor<1, 3, Number>
   cross_product(const Tensor<1, 3, Number> &a, const Tensor<1, 3, Number> &b)
   {
     return cross_product_3d(a, b);
   }
 
   template <typename Number>
-  Tensor<1, 2, Number>
+  DEAL_II_ALWAYS_INLINE inline Tensor<1, 2, Number>
   cross_product(const Number &a, const Tensor<1, 2, Number> &b)
   {
     Tensor<1, 2, Number> c;
@@ -355,7 +355,7 @@ namespace Sintering
 
   // Compute skew tensor of a vector
   template <typename Number>
-  Tensor<2, 3, Number>
+  DEAL_II_ALWAYS_INLINE inline Tensor<2, 3, Number>
   skew(const Tensor<1, 3, Number> &a)
   {
     Tensor<2, 3, Number> A;
@@ -370,7 +370,7 @@ namespace Sintering
   }
 
   template <typename Number>
-  Tensor<1, 2, Number>
+  DEAL_II_ALWAYS_INLINE inline Tensor<1, 2, Number>
   skew(const Tensor<1, 2, Number> &a)
   {
     Tensor<1, 2, Number> A;
@@ -381,7 +381,7 @@ namespace Sintering
   }
 
   template <int dim, typename Number>
-  Tensor<2, dim, Number>
+  DEAL_II_ALWAYS_INLINE inline Tensor<2, dim, Number>
   diagonal_matrix(const Number &fac = 1.)
   {
     Tensor<2, dim, Number> I;
@@ -393,7 +393,7 @@ namespace Sintering
   }
 
   template <int dim, typename Number>
-  Tensor<1, dim, Number>
+  DEAL_II_ALWAYS_INLINE inline Tensor<1, dim, Number>
   unit_vector(const Tensor<1, dim, Number> &vec)
   {
     Number nrm = vec.norm();
@@ -421,7 +421,7 @@ namespace Sintering
   }
 
   template <int dim, typename Number>
-  Tensor<2, dim, Number>
+  DEAL_II_ALWAYS_INLINE inline Tensor<2, dim, Number>
   projector_matrix(const Tensor<1, dim, Number> vec, const Number &fac = 1.)
   {
     auto tensor = diagonal_matrix<dim, Number>(1.) - outer_product(vec, vec);


### PR DESCRIPTION
I tried out the tensorial mobility and was somewhat horrified by the throughput:

dim | fe_type | n_dofs | n_components | t_helmholtz | t_sintering |   | diff
-- | -- | -- | -- | -- | -- | -- | --
3 | FE_Q | 2146689 | 4 | 9.24E-01 | 6.59E+00 |   | 7.1
3 | FE_Q | 2146689 | 5 | 1.21E+00 | 1.29E+01 |   | 10.7
3 | FE_Q | 2146689 | 6 | 1.51E+00 | 2.23E+01 |   | 14.8
3 | FE_Q | 2146689 | 7 | 1.78E+00 | 3.44E+01 |   | 19.3
3 | FE_Q | 2146689 | 8 | 2.55E+00 | 4.96E+01 |   | 19.5
3 | FE_Q | 2146689 | 9 | 2.93E+00 | 6.77E+01 |   | 23.1
3 | FE_Q | 2146689 | 10 | 3.24E+00 | 8.91E+01 |   | 27.5
3 | FE_Q | 2146689 | 11 | 3.54E+00 | 1.16E+02 |   | 32.7
3 | FE_Q | 2146689 | 12 | 3.96E+00 | 1.40E+02 |   | 35.2

By doing some simple inlining, I got a speedup of up to 5!

dim | fe_type | n_dofs | n_components | t_helmholtz | t_sintering |   | diff
-- | -- | -- | -- | -- | -- | -- | --
3 | FE_Q | 2146689 | 4 | 9.21E-01 | 2.67E+00 |   | 2.9
3 | FE_Q | 2146689 | 5 | 1.20E+00 | 4.37E+00 |   | 3.6
3 | FE_Q | 2146689 | 6 | 1.51E+00 | 6.32E+00 |   | 4.2
3 | FE_Q | 2146689 | 7 | 1.80E+00 | 8.87E+00 |   | 4.9
3 | FE_Q | 2146689 | 8 | 2.47E+00 | 1.14E+01 |   | 4.6
3 | FE_Q | 2146689 | 9 | 2.82E+00 | 1.48E+01 |   | 5.3
3 | FE_Q | 2146689 | 10 | 3.19E+00 | 1.87E+01 |   | 5.9
3 | FE_Q | 2146689 | 11 | 3.50E+00 | 2.30E+01 |   | 6.6
3 | FE_Q | 2146689 | 12 | 3.90E+00 | 2.78E+01 |   | 7.1

The timings are still too bad. But hopefully reducing redundant computations, exploiting of symmetries, and the computation of the gradients of eta on-the-fly will help!?

references #308 