### PR TITLE
Micro benchmark: matrix-based extension

### DIFF
--- a/applications/sintering/sintering_throughput.cc
+++ b/applications/sintering/sintering_throughput.cc
@@ -246,14 +246,22 @@ main(int argc, char **argv)
     else
       {
         table.add_value("t_" + label + "_mb", 0.0);
+        table.set_scientific("t_" + label + "_mb", true);
         table.add_value("nnz_" + label, 0);
       }
   };
 
-  for (unsigned int n_grains = 2; n_grains <= max_sintering_grains; ++n_grains)
-    {
-      const unsigned int n_components = n_grains + 2;
+  const auto test_operator_dummy = [&](const std::string label) {
+    table.add_value("t_" + label + "_mf", 0);
+    table.set_scientific("t_" + label + "_mf", true);
+    table.add_value("t_" + label + "_mb", 0);
+    table.set_scientific("t_" + label + "_mb", true);
+    table.add_value("nnz_" + label, 0);
+  };
 
+  for (unsigned int n_components = 1; n_components <= max_sintering_grains + 2;
+       ++n_components)
+    {
       table.add_value("dim", dim);
       table.add_value("fe_type", fe_type);
       table.add_value("n_dofs", dof_handler.n_dofs());
@@ -267,7 +275,7 @@ main(int argc, char **argv)
           test_operator(helmholtz_operator, "helmholtz");
         }
 
-      if (true) // test sintering operator
+      if (n_components >= 4) // test sintering operator
         {
           const std::shared_ptr<MobilityProvider> mobility_provider =
             std::make_shared<ProviderAbstract>(Mvol, Mvap, Msurf, Mgb, L);
@@ -303,6 +311,10 @@ main(int argc, char **argv)
 
 
           test_operator(sintering_operator, "sintering");
+        }
+      else
+        {
+          test_operator_dummy("sintering");
         }
     }
 


### PR DESCRIPTION
dim | fe_type | n_dofs | n_components | t_helmholtz_mf | t_helmholtz_mb | nnz_helmholtz | t_sintering_mf | t_sintering_mb | nnz_sintering
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
3 | FE_Q | 2146689 | 1 | 3.38E-01 | 3.75E-01 | 57066625 | 0 | 0 | 0
3 | FE_Q | 2146689 | 2 | 4.84E-01 | 1.43E+00 | 228266500 | 0 | 0 | 0
3 | FE_Q | 2146689 | 3 | 8.09E-01 | 3.06E+00 | 513599625 | 0 | 0 | 0
3 | FE_Q | 2146689 | 4 | 8.82E-01 | 5.28E+00 | 913066000 | 1.57E+00 | 5.34E+00 | 913066000
3 | FE_Q | 2146689 | 5 | 1.17E+00 | 8.14E+00 | 1426665625 | 2.19E+00 | 8.16E+00 | 1426665625
3 | FE_Q | 2146689 | 6 | 1.46E+00 | 1.18E+01 | 2054398500 | 2.64E+00 | 1.20E+01 | 2054398500
3 | FE_Q | 2146689 | 7 | 1.75E+00 | 0.00E+00 | 0 | 3.18E+00 | 0.00E+00 | 0
3 | FE_Q | 2146689 | 8 | 2.43E+00 | 0.00E+00 | 0 | 3.80E+00 | 0.00E+00 | 0
3 | FE_Q | 2146689 | 9 | 2.82E+00 | 0.00E+00 | 0 | 4.59E+00 | 0.00E+00 | 0
3 | FE_Q | 2146689 | 10 | 3.12E+00 | 0.00E+00 | 0 | 5.36E+00 | 0.00E+00 | 0
3 | FE_Q | 2146689 | 11 | 3.45E+00 | 0.00E+00 | 0 | 6.18E+00 | 0.00E+00 | 0
3 | FE_Q | 2146689 | 12 | 3.86E+00 | 0.00E+00 | 0 | 7.17E+00 | 0.00E+00 | 0

references #308 