### PR TITLE
Adjust initial top fraction

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/driver.h
+++ b/applications/sintering/include/pf-applications/sintering/driver.h
@@ -1679,9 +1679,11 @@ namespace Sintering
           const double bottom_fraction_of_cells =
             params.adaptivity_data.bottom_fraction_of_cells;
           if (params.geometry_data.global_refinement == "None")
-            top_fraction_of_cells = 0.9;
+            top_fraction_of_cells *= 3;
           else if (params.geometry_data.global_refinement == "Base")
-            top_fraction_of_cells = 0.8;
+            top_fraction_of_cells *= 2.5;
+
+          top_fraction_of_cells = std::min(top_fraction_of_cells, 1.0);
 
           const unsigned int n_init_refinements =
             std::max(std::min(tria.n_global_levels() - 1,


### PR DESCRIPTION
These settings seems to deliver better comparable meshes for both `FE_Q` and `FE_Q_iso_Q1`.

I also observed that for to keep the number of dofs for `FE_Q_iso_Q1` small and somewhat similar to `FE_Q`, the following refinement settings have to be used:
```json
"Adaptivity": {
    "TopFractionOfCells": "0.0",
    "BottomFractionOfCells": "1.0"
}
```
i.e. only those cells are refined which belong to the interface, everything else is attempted to be coarsened.

PS: @peterrum, what is the main advantange of `refine_and_coarsen_fixed_fraction()` over `refine_and_coarsen_fixed_number()` from your experience? I found the behavior of `refine_and_coarsen_fixed_fraction()` is a bit strange sometimes for `FE_Q_iso_Q1`.