### PR TITLE
Add include fe_q_iso_q1.h

### DIFF
--- a/applications/sintering/sintering_throughput.cc
+++ b/applications/sintering/sintering_throughput.cc
@@ -41,6 +41,9 @@ static_assert(false, "No grains number has been given!");
 #include <deal.II/base/mpi.h>
 #include <deal.II/base/revision.h>
 
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_q_iso_q1.h>
+
 #ifdef LIKWID_PERFMON
 #  include <likwid.h>
 #endif


### PR DESCRIPTION
The code did not compile for me without
```c++
#include <deal.II/fe/fe_q_iso_q1.h>
```
I also added `fe_q.h` for consistency.