### PR TITLE
Check also average value during the mesh refinement at the interface

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/driver.h
+++ b/applications/sintering/include/pf-applications/sintering/driver.h
@@ -1481,12 +1481,15 @@ namespace Sintering
                         }
                     }
 
-                  // In case if a cell has values, e.g., close to 0 or 1
-                  val_avg /= values.size();
-                  if (val_min < val_avg && val_avg < val_max)
+                  if (!cell->refine_flag_set())
                     {
-                      cell->clear_coarsen_flag();
-                      cell->set_refine_flag();
+                      // In case if a cell has values, e.g., close to 0 or 1
+                      val_avg /= values.size();
+                      if (val_min < val_avg && val_avg < val_max)
+                        {
+                          cell->clear_coarsen_flag();
+                          cell->set_refine_flag();
+                        }
                     }
 
                   if (cell->refine_flag_set())


### PR DESCRIPTION
To mark for refinement cells like this:
![image](https://user-images.githubusercontent.com/8836201/210361803-93d2553d-2f56-479d-9e94-2a05779ca809.png)

Originally such a cell would not get refined and the following mesh would emerge:
![image](https://user-images.githubusercontent.com/8836201/210361707-538e007d-f97a-42e5-a8b8-1c62fb2276b2.png)
