### PR TITLE
Switch to non-flexible restart

### DIFF
--- a/applications/sintering/analysis_examples/3d_default.json
+++ b/applications/sintering/analysis_examples/3d_default.json
@@ -90,7 +90,7 @@
         "OutputMemoryConsumption": "false"
     },
     "Restart": {
-        "FlexibleOutput": "true",
+        "FlexibleOutput": "false",
         "FullHistory": "true",
         "Interval": "500",
         "MaximalOutput": "1",

--- a/applications/sintering/analysis_examples/49particles_delta_min_40.json
+++ b/applications/sintering/analysis_examples/49particles_delta_min_40.json
@@ -98,7 +98,7 @@
         "DesirableLinearIterations": "100",
         "DesirableNewtonIterations": "5",
         "GrowthFactor": "1.2",
-        "TimeEnd": "15000",
+        "TimeEnd": "10",
         "TimeStart": "0",
         "TimeStepInit": "0.1",
         "TimeStepMax": "100",

--- a/applications/sintering/analysis_examples/default.json
+++ b/applications/sintering/analysis_examples/default.json
@@ -109,7 +109,7 @@
         "OutputMemoryConsumption": "false"
     },
     "Restart": {
-        "FlexibleOutput": "true",
+        "FlexibleOutput": "false",
         "FullHistory": "true",
         "Interval": "500",
         "MaximalOutput": "0",

--- a/applications/sintering/include/pf-applications/sintering/parameters.h
+++ b/applications/sintering/include/pf-applications/sintering/parameters.h
@@ -209,7 +209,7 @@ namespace Sintering
     std::string  type            = "never";
     double       interval        = 10.0;
     unsigned int max_output      = 0;
-    bool         flexible_output = true;
+    bool         flexible_output = false;
     bool         full_history    = true;
   };
 


### PR DESCRIPTION
This PR proposes to switch the type of restart files. The native deal.II is horribly slow (6x). I would say that we normally restart with the same number of processes so that this should be fine!

```
+----------------------------------------------------------+------------------+------------+------------------+
| Total wallclock time elapsed                             |     80.44s     4 |     80.44s |     80.44s   142 |
|                                                          |                  |                               |
| Section                                      | no. calls |   min time  rank |   avg time |   max time  rank |
+----------------------------------------------------------+------------------+------------+------------------+
| execute_coarsening_and_refinement            |         6 |     1.616s     0 |     1.616s |     1.617s   225 |
| grain_tracker                                |         1 |     1.752s   237 |     1.752s |     1.752s   100 |
| grain_tracker::initial_setup                 |         1 |    0.3522s   234 |    0.3527s |    0.3562s     0 |
| grain_tracker::remap                         |         1 |     1.337s   105 |     1.361s |     1.394s     0 |
| initialize_solution                          |         7 |    0.3704s    95 |     0.371s |    0.3715s     0 |
| output_result                                |         1 |    0.5932s    51 |    0.6073s |     1.047s     0 |
| time_loop                                    |        18 |     75.65s     0 |     76.09s |      76.1s    51 |
| time_loop::execute_coarsening_and_refinement |         1 |     2.814s     0 |     2.815s |     2.815s   199 |
| time_loop::newton                            |        18 |     58.13s   238 |     58.15s |     58.15s     0 |
| time_loop::newton::residual                  |        80 |     1.516s   239 |     1.883s |     2.021s    38 |
| time_loop::newton::setup_jacobian            |        62 |     1.035s     0 |     1.233s |     2.136s   224 |
| time_loop::newton::setup_preconditioner      |        18 |     17.56s   225 |     17.81s |     17.87s    22 |
| time_loop::newton::solve_with_jacobian       |        62 |     35.84s   224 |     36.49s |     36.65s     1 |
| time_loop::output_result                     |         1 |    0.5445s   159 |    0.5605s |    0.9911s     0 |
| time_loop::restart                           |         1 |      13.6s     0 |     14.03s |     14.05s   173 |
+----------------------------------------------------------+------------------+------------+------------------+
```