### PR TITLE
Make it work if GT was not in use

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/postprocessors.h
+++ b/applications/sintering/include/pf-applications/sintering/postprocessors.h
@@ -181,7 +181,12 @@ namespace Sintering
         }
 
       if (grain_tracker)
-        grain_tracker->track(vector, n_grains, true);
+        {
+          if (grain_tracker->get_grains().empty())
+            grain_tracker->initial_setup(vector, n_grains);
+          else
+            grain_tracker->track(vector, n_grains, true);
+        }
 
 
 


### PR DESCRIPTION
If grain tracker is not used in `driver`, this output used to crash.