### PR TITLE
Add benchmark with FEValues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ ADD_SUBDIRECTORY(applications/allen_cahn)
 ADD_SUBDIRECTORY(applications/cahn_hilliard)
 ADD_SUBDIRECTORY(applications/sintering)
 ADD_SUBDIRECTORY(applications/structural)
+ADD_SUBDIRECTORY(benchmarks)
 
 if(EXISTS ${CMAKE_SOURCE_DIR}/tests/CMakeLists.txt)
   set(DEAL_II_HAVE_TESTS_DIRECTORY TRUE)

--- a/applications/sintering/include/pf-applications/sintering/operator_sintering_generic.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_sintering_generic.h
@@ -88,9 +88,10 @@ namespace Sintering
     DEAL_II_ALWAYS_INLINE inline std::tuple<
       typename FECellIntegratorType::value_type,
       typename FECellIntegratorType::gradient_type>
-    apply(const unsigned int                                  q,
-          const typename FECellIntegratorType::value_type &   value,
-          const typename FECellIntegratorType::gradient_type &gradient) const
+    operator()(
+      const unsigned int                                  q,
+      const typename FECellIntegratorType::value_type &   value,
+      const typename FECellIntegratorType::gradient_type &gradient) const
     {
       typename FECellIntegratorType::value_type    value_result;
       typename FECellIntegratorType::gradient_type gradient_result;
@@ -244,7 +245,7 @@ namespace Sintering
 
     template <typename T1, typename T2>
     DEAL_II_ALWAYS_INLINE inline std::tuple<T1, T2>
-    apply(const unsigned int q, const T1 &value, const T2 &gradient) const
+    operator()(const unsigned int q, const T1 &value, const T2 &gradient) const
     {
       T1 value_result;
       T2 gradient_result;
@@ -621,7 +622,7 @@ namespace Sintering
           const auto gradient = phi.get_gradient(q);
 
           const auto [value_result, gradient_result] =
-            quad_op.apply(q, value, gradient);
+            quad_op(q, value, gradient);
 
           phi.submit_value(value_result, q);
           phi.submit_gradient(gradient_result, q);
@@ -657,8 +658,7 @@ namespace Sintering
           const auto value    = phi.get_value(q);
           const auto gradient = phi.get_gradient(q);
 
-          auto [value_result, gradient_result] =
-            quad_op.apply(q, value, gradient);
+          auto [value_result, gradient_result] = quad_op(q, value, gradient);
 
           // 4) add advection contributations -> influences c AND etas
           if (this->advection.enabled())

--- a/applications/sintering/include/pf-applications/sintering/operator_sintering_generic.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_sintering_generic.h
@@ -251,9 +251,9 @@ namespace Sintering
       T2 gradient_result;
 
       if constexpr (!std::is_same<T1, VectorizedArrayType>::value)
-        if constexpr (T1::rank > 2)
+        if constexpr (T1::dimension >= 2)
           {
-            const unsigned int n_comp   = T1::rank;
+            const unsigned int n_comp   = T1::dimension;
             const unsigned int n_grains = n_comp - 2;
 
             const VectorizedArrayType *etas_value = &value[0] + 2;
@@ -264,12 +264,6 @@ namespace Sintering
               PowerHelper<n_grains, 2>::power_sum(etas_value);
             const auto etas_value_power_3_sum =
               PowerHelper<n_grains, 3>::power_sum(etas_value);
-
-            Tensor<1, n_comp, VectorizedArrayType> value_result;
-            Tensor<1, n_comp, Tensor<1, dim, VectorizedArrayType>>
-              gradient_result;
-
-
 
             // 1) process c row
             if (with_time_derivative >= 1)
@@ -284,8 +278,6 @@ namespace Sintering
                                                   etas_gradient,
                                                   gradient[1]);
 
-
-
             // 2) process mu row
             value_result[1] =
               -value[1] + free_energy.df_dc(value[0],
@@ -293,7 +285,6 @@ namespace Sintering
                                             etas_value_power_2_sum,
                                             etas_value_power_3_sum);
             gradient_result[1] = kappa_c * gradient[0];
-
 
 
             // 3) process eta rows

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,0 +1,16 @@
+
+
+FILE(GLOB SOURCE_FILES "*.cc")
+
+FOREACH ( source_file ${SOURCE_FILES} )
+
+  GET_FILENAME_COMPONENT(file_name ${source_file} NAME)
+
+  IF(NOT _cmp_dummy AND NOT _cmp_sintering_circle AND NOT _cmp_sintering_cloud)
+    STRING( REPLACE ".cc" "" exec ${file_name} )
+    ADD_EXECUTABLE( ${exec} ${source_file})
+    DEAL_II_SETUP_TARGET(${exec})
+    TARGET_LINK_LIBRARIES(${exec} "pf-applications")
+  ENDIF()
+
+ENDFOREACH ( source_file ${SOURCE_FILES} )

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -17,6 +17,7 @@ FOREACH ( source_file ${SOURCE_FILES} )
   ADD_EXECUTABLE( ${exec} ${source_file})
   DEAL_II_SETUP_TARGET(${exec})
   TARGET_LINK_LIBRARIES(${exec} "pf-applications")
+  target_include_directories(${exec} PUBLIC "../applications/sintering/include")
   
   # add LIKWID to test if requested
   IF(${LIKWID_TO_BE_USED})

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -3,14 +3,30 @@
 FILE(GLOB SOURCE_FILES "*.cc")
 
 FOREACH ( source_file ${SOURCE_FILES} )
-
+  
   GET_FILENAME_COMPONENT(file_name ${source_file} NAME)
-
-  IF(NOT _cmp_dummy AND NOT _cmp_sintering_circle AND NOT _cmp_sintering_cloud)
-    STRING( REPLACE ".cc" "" exec ${file_name} )
-    ADD_EXECUTABLE( ${exec} ${source_file})
-    DEAL_II_SETUP_TARGET(${exec})
-    TARGET_LINK_LIBRARIES(${exec} "pf-applications")
+  
+  # determine if LIKWID is requested (if the file name contains .likwid)
+  STRING( FIND ${file_name} ".likwid" LIKWID_TO_BE_USED)
+  
+  IF(${LIKWID_TO_BE_USED})
+    STRING( REPLACE ".likwid" "" file_name ${file_name} )
   ENDIF()
-
+  
+  STRING( REPLACE ".cc" "" exec ${file_name} )
+  ADD_EXECUTABLE( ${exec} ${source_file})
+  DEAL_II_SETUP_TARGET(${exec})
+  TARGET_LINK_LIBRARIES(${exec} "pf-applications")
+  
+  # add LIKWID to test if requested
+  IF(${LIKWID_TO_BE_USED})
+    FIND_LIBRARY(LIKWID likwid HINTS $ENV{LIKWID_LIB})
+    
+    IF(LIKWID)
+      TARGET_COMPILE_DEFINITIONS(${exec} PUBLIC LIKWID_PERFMON)
+      TARGET_INCLUDE_DIRECTORIES(${exec} PUBLIC $ENV{LIKWID_INCLUDE})
+      TARGET_LINK_LIBRARIES(${exec} ${LIKWID})
+    ENDIF()
+  ENDIF()
+  
 ENDFOREACH ( source_file ${SOURCE_FILES} )

--- a/benchmarks/README.MD
+++ b/benchmarks/README.MD
@@ -1,0 +1,3 @@
+```bash
+mpirun -np 40 ./benchmarks/layer_wise ../benchmarks/layer_wise_00.json
+```

--- a/benchmarks/README.MD
+++ b/benchmarks/README.MD
@@ -1,3 +1,7 @@
 ```bash
-mpirun -np 40 ./benchmarks/layer_wise ../benchmarks/layer_wise_00.json
+mpirun -np 40 ./benchmarks/layer_wise ../benchmarks/layer_wise_00.json | tee layer_wise_00.output
+mpirun -np 40 ./benchmarks/layer_wise ../benchmarks/layer_wise_01.json | tee layer_wise_01.output
+mpirun -np 40 ./benchmarks/layer_wise ../benchmarks/layer_wise_02.json | tee layer_wise_02.output
+mpirun -np 40 ./benchmarks/layer_wise ../benchmarks/layer_wise_03.json | tee layer_wise_03.output
+
 ```

--- a/benchmarks/fe_values_vs_fe_eval.cc
+++ b/benchmarks/fe_values_vs_fe_eval.cc
@@ -1,0 +1,276 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2022 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Test performance of the sintering operator
+
+#include <deal.II/base/convergence_table.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/revision.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_q_iso_q1.h>
+#include <deal.II/fe/fe_system.h>
+
+#include <deal.II/grid/grid_generator.h>
+
+#include <deal.II/matrix_free/fe_evaluation.h>
+#include <deal.II/matrix_free/matrix_free.h>
+
+#include <pf-applications/base/performance.h>
+
+#ifdef LIKWID_PERFMON
+#  include <likwid.h>
+#endif
+
+using namespace dealii;
+
+
+template <int dim, int n_components, typename Number, typename VectorType>
+void
+helmholtz_operator_fe_values_0(VectorType &           dst,
+                               const VectorType &     src,
+                               const Mapping<dim> &   mapping,
+                               const DoFHandler<dim> &dof_handler,
+                               const Quadrature<dim> &quadrature)
+{
+  const auto &fe = dof_handler.get_fe();
+
+  FEValues<dim> fe_values(mapping,
+                          fe,
+                          quadrature,
+                          update_values | update_gradients | update_JxW_values);
+
+  std::vector<Tensor<1, n_components, Number>> values(
+    fe_values.n_quadrature_points);
+  std::vector<Tensor<1, n_components, Tensor<1, dim, Number>>> gradients(
+    fe_values.n_quadrature_points);
+
+  Vector<Number> src_local(fe_values.dofs_per_cell);
+  Vector<Number> dst_local(fe_values.dofs_per_cell);
+
+  src.update_ghost_values();
+
+
+  for (const auto &cell : dof_handler.active_cell_iterators())
+    {
+      if (cell->is_locally_owned() == false)
+        continue;
+
+      fe_values.reinit(cell);
+
+      cell->get_dof_values(src, src_local); // TODO: constraints
+
+      for (const auto q : fe_values.quadrature_point_indices())
+        for (unsigned int c = 0; c < n_components; ++c)
+          {
+            Number                 value = 0.0;
+            Tensor<1, dim, Number> gradient;
+
+            for (const auto i : fe_values.dof_indices())
+              {
+                value +=
+                  src_local[i] * fe_values.shape_value_component(i, q, c);
+                gradient +=
+                  src_local[i] * fe_values.shape_grad_component(i, q, c);
+              }
+
+            values[q][c]    = value;
+            gradients[q][c] = gradient;
+          }
+
+      for (const auto q : fe_values.quadrature_point_indices())
+        {
+          values[q] *= fe_values.JxW(q);
+          gradients[q] *= fe_values.JxW(q);
+        }
+
+      for (const auto i : fe_values.dof_indices())
+        {
+          dst_local[i] = 0.0;
+
+          for (const auto q : fe_values.quadrature_point_indices())
+            {
+              for (unsigned int c = 0; c < n_components; ++c)
+                {
+                  dst_local[i] +=
+                    values[q][c] * fe_values.shape_value_component(i, q, c) +
+                    gradients[q][c] * fe_values.shape_grad_component(i, q, c);
+                }
+            }
+        }
+
+      cell->distribute_local_to_global(dst_local, dst); // TODO: constraints
+    }
+
+  src.zero_out_ghost_values();
+  dst.compress(VectorOperation::add);
+}
+
+
+template <int dim, int fe_degree, int n_q_points, int n_components, typename Number, typename VectorType>
+void
+helmholtz_operator_fe_evaluation(VectorType &           dst,
+                               const VectorType &     src,
+                               const MatrixFree<dim, Number> &   matrix_free)
+{
+    matrix_free.template cell_loop<VectorType, VectorType>([](const auto & data, auto & dst, const auto & src, const auto & range){
+
+        FEEvaluation<dim, fe_degree, n_q_points, n_components, Number> phi(data);
+        
+        for(unsigned int cell = range.first; cell < range.second; ++cell)
+        {
+            phi.reinit(cell);
+
+            phi.gather_evaluate(src,
+                          EvaluationFlags::values | EvaluationFlags::gradients);
+
+            for (unsigned int q_index = 0; q_index < phi.n_q_points; ++q_index)
+              {
+                phi.submit_value(phi.get_value(q_index), q_index);
+                phi.submit_gradient(phi.get_gradient(q_index), q_index);
+              }
+
+            phi.integrate_scatter(EvaluationFlags::values |
+                              EvaluationFlags::gradients,
+                            dst);
+
+        }
+
+    }, dst, src, true);
+}
+
+#define EXPAND_OPERATIONS(OPERATION)             \
+  switch (n_components)                          \
+    {                                            \
+      case 1:                                    \
+        {                                        \
+          OPERATION(1, 0);                       \
+        }                                        \
+        break;                                   \
+      case 2:                                    \
+        {                                        \
+          OPERATION(2, 0);                       \
+        }                                        \
+        break;                                   \
+      case 3:                                    \
+        {                                        \
+          OPERATION(3, 0);                       \
+        }                                        \
+        break;                                   \
+      case 4:                                    \
+        {                                        \
+          OPERATION(4, 0);                       \
+        }                                        \
+        break;                                   \
+      default:                                   \
+        AssertThrow(false, ExcNotImplemented()); \
+    }
+
+
+// clang-format off
+/**
+ * likwid-mpirun -np 40 -f -g CACHES   -m -O ./applications/sintering/sintering-throughput
+ * likwid-mpirun -np 40 -f -g FLOPS_DP -m -O ./applications/sintering/sintering-throughput
+ */
+// clang-format on
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv, 1);
+
+#ifdef LIKWID_PERFMON
+  LIKWID_MARKER_INIT;
+  LIKWID_MARKER_THREADINIT;
+#endif
+
+  constexpr unsigned int dim                  = 3;
+  constexpr unsigned int fe_degree            = 1;
+  constexpr unsigned int n_q_points          = fe_degree + 1;
+  constexpr unsigned int n_global_refinements = 7; // TODO
+  constexpr unsigned int n_repetitions        = 1;
+  using Number                            = double;
+  using VectorType = LinearAlgebra::distributed::Vector<Number>;
+
+  const std::string fe_type = "FE_Q";
+
+  ConvergenceTable table;
+
+  for (unsigned int n_components = 1; n_components <= 4; ++n_components)
+    {
+      const FESystem<dim>  fe(FE_Q<dim>(fe_degree), n_components);
+      const QGauss<dim>    quadrature(n_q_points);
+      const MappingQ1<dim> mapping;
+
+      parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD);
+      GridGenerator::hyper_cube(tria);
+      tria.refine_global(n_global_refinements);
+
+      DoFHandler<dim> dof_handler(tria);
+      dof_handler.distribute_dofs(fe);
+
+      AffineConstraints<Number> constraints;
+
+      typename MatrixFree<dim, Number>::AdditionalData
+        additional_data;
+      additional_data.mapping_update_flags =
+        update_values | update_gradients | update_quadrature_points;
+      additional_data.overlap_communication_computation = false;
+
+      MatrixFree<dim, Number> matrix_free;
+      matrix_free.reinit(
+        mapping, dof_handler, constraints, quadrature, additional_data);
+
+      table.add_value("dim", dim);
+      table.add_value("fe_type", fe_type);
+      table.add_value("n_dofs", dof_handler.n_dofs());
+      table.add_value("n_components", n_components);
+
+      VectorType src, dst;
+      matrix_free.initialize_dof_vector(src);
+      matrix_free.initialize_dof_vector(dst);
+
+      src = 1.0;
+
+#define OPERATION(c, d)                               \
+  const auto time_0 = run_measurement(                \
+    [&]() {                                           \
+      helmholtz_operator_fe_values_0<dim, c, Number>( \
+        dst, src, mapping, dof_handler, quadrature);  \
+    },                                                \
+    n_repetitions);                                   \
+  table.add_value("t_0", time_0);                     \
+  table.set_scientific("t_0", true);                  \
+  const auto time_1 = run_measurement(                \
+    [&]() {                                           \
+      helmholtz_operator_fe_evaluation<dim, fe_degree, n_q_points, c, Number>( \
+        dst, src, matrix_free);   \
+    },                                                \
+    n_repetitions);                                   \
+  table.add_value("t_1", time_1);                     \
+  table.set_scientific("t_1", true);                  \
+
+
+      EXPAND_OPERATIONS(OPERATION);
+
+#undef OPERATION
+    }
+
+  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+    table.write_text(std::cout, TableHandler::TextOutputFormat::org_mode_table);
+
+#ifdef LIKWID_PERFMON
+  LIKWID_MARKER_CLOSE;
+#endif
+}

--- a/benchmarks/fe_values_vs_fe_eval.cc
+++ b/benchmarks/fe_values_vs_fe_eval.cc
@@ -61,7 +61,7 @@ helmholtz_operator_fe_values_0(VectorType &           dst,
   Vector<Number> dst_local(fe_values.dofs_per_cell);
 
   src.update_ghost_values();
-
+  dst = 0.0;
 
   for (const auto &cell : dof_handler.active_cell_iterators())
     {
@@ -146,7 +146,7 @@ helmholtz_operator_fe_values_1(VectorType &           dst,
     fe_values.dofs_per_cell / n_components;
 
   src.update_ghost_values();
-
+  dst = 0.0;
 
   for (const auto &cell : dof_handler.active_cell_iterators())
     {

--- a/benchmarks/fe_values_vs_fe_eval.cc
+++ b/benchmarks/fe_values_vs_fe_eval.cc
@@ -347,6 +347,9 @@ main(int argc, char **argv)
     n_repetitions);                                                            \
   table.add_value("t_0", time_0);                                              \
   table.set_scientific("t_0", true);                                           \
+  table.add_value("l_0", dst.l2_norm());                                       \
+  table.set_scientific("l_0", true);                                           \
+                                                                               \
   const auto time_1 = run_measurement(                                         \
     [&]() {                                                                    \
       helmholtz_operator_fe_values_1<dim, c, Number>(                          \
@@ -355,6 +358,9 @@ main(int argc, char **argv)
     n_repetitions);                                                            \
   table.add_value("t_1", time_1);                                              \
   table.set_scientific("t_1", true);                                           \
+  table.add_value("l_1", dst.l2_norm());                                       \
+  table.set_scientific("l_1", true);                                           \
+                                                                               \
   const auto time_2 = run_measurement(                                         \
     [&]() {                                                                    \
       helmholtz_operator_fe_evaluation<dim, fe_degree, n_q_points, c, Number>( \
@@ -362,7 +368,9 @@ main(int argc, char **argv)
     },                                                                         \
     n_repetitions);                                                            \
   table.add_value("t_2", time_2);                                              \
-  table.set_scientific("t_2", true);
+  table.set_scientific("t_2", true);                                           \
+  table.add_value("l_2", dst.l2_norm());                                       \
+  table.set_scientific("l_2", true);
 
 
       EXPAND_OPERATIONS(OPERATION);

--- a/benchmarks/layer_wise.likwid.cc
+++ b/benchmarks/layer_wise.likwid.cc
@@ -26,6 +26,8 @@
 #  include <likwid.h>
 #endif
 
+//#define WITH_TENSORIAL_MOBILITY
+
 #define MAX_SINTERING_GRAINS 10
 #define MAX_N_COMPONENTS MAX_SINTERING_GRAINS + 2
 

--- a/benchmarks/layer_wise.likwid.cc
+++ b/benchmarks/layer_wise.likwid.cc
@@ -27,6 +27,7 @@
 #endif
 
 #define MAX_SINTERING_GRAINS 10
+#define MAX_N_COMPONENTS MAX_SINTERING_GRAINS + 2
 
 #include <pf-applications/sintering/advection.h>
 #include <pf-applications/sintering/mobility.h>
@@ -174,38 +175,83 @@ create_op(const unsigned int                                  n_components,
           const MatrixFree<dim, Number, VectorizedArrayType> &matrix_free,
           const QPointType &                                  q_point_operator)
 {
+#if MAX_N_COMPONENTS >= 1
   if (n_components == 1)
     return create_op<1>(level, matrix_free, q_point_operator);
-  else if (n_components == 2)
+  else
+#endif
+#if MAX_N_COMPONENTS >= 2
+    if (n_components == 2)
     return create_op<2>(level, matrix_free, q_point_operator);
-  else if (n_components == 3)
+  else
+#endif
+#if MAX_N_COMPONENTS >= 3
+    if (n_components == 3)
     return create_op<3>(level, matrix_free, q_point_operator);
-  else if (n_components == 4)
+  else
+#endif
+#if MAX_N_COMPONENTS >= 4
+    if (n_components == 4)
     return create_op<4>(level, matrix_free, q_point_operator);
-#if 0
-  else if (n_components == 5)
+  else
+#endif
+#if MAX_N_COMPONENTS >= 5
+    if (n_components == 5)
     return create_op<5>(level, matrix_free, q_point_operator);
-  else if (n_components == 6)
+  else
+#endif
+#if MAX_N_COMPONENTS >= 6
+    if (n_components == 6)
     return create_op<6>(level, matrix_free, q_point_operator);
-  else if (n_components == 7)
+  else
+#endif
+#if MAX_N_COMPONENTS >= 7
+    if (n_components == 7)
     return create_op<7>(level, matrix_free, q_point_operator);
-  else if (n_components == 8)
+  else
+#endif
+#if MAX_N_COMPONENTS >= 8
+    if (n_components == 8)
     return create_op<8>(level, matrix_free, q_point_operator);
-  else if (n_components == 9)
+  else
+#endif
+#if MAX_N_COMPONENTS >= 9
+    if (n_components == 9)
     return create_op<9>(level, matrix_free, q_point_operator);
-  else if (n_components == 10)
+  else
+#endif
+#if MAX_N_COMPONENTS >= 10
+    if (n_components == 10)
     return create_op<10>(level, matrix_free, q_point_operator);
-  else if (n_components == 11)
+  else
+#endif
+#if MAX_N_COMPONENTS >= 11
+    if (n_components == 11)
     return create_op<11>(level, matrix_free, q_point_operator);
-  else if (n_components == 12)
+  else
+#endif
+#if MAX_N_COMPONENTS >= 12
+    if (n_components == 12)
     return create_op<12>(level, matrix_free, q_point_operator);
-  else if (n_components == 13)
+  else
+#endif
+#if MAX_N_COMPONENTS >= 13
+    if (n_components == 13)
     return create_op<13>(level, matrix_free, q_point_operator);
-  else if (n_components == 14)
+  else
+#endif
+#if MAX_N_COMPONENTS >= 14
+    if (n_components == 14)
     return create_op<14>(level, matrix_free, q_point_operator);
-  else if (n_components == 15)
+  else
+#endif
+#if MAX_N_COMPONENTS >= 15
+    if (n_components == 15)
     return create_op<15>(level, matrix_free, q_point_operator);
-  else if (n_components == 16)
+  else
+#endif
+#if MAX_N_COMPONENTS >= 16
+    if (n_components == 16)
     return create_op<16>(level, matrix_free, q_point_operator);
 #endif
 

--- a/benchmarks/layer_wise.likwid.cc
+++ b/benchmarks/layer_wise.likwid.cc
@@ -144,6 +144,7 @@ create_op(const unsigned int                                  n_components,
     return create_op<3>(level, matrix_free);
   else if (n_components == 4)
     return create_op<4>(level, matrix_free);
+#if 0
   else if (n_components == 5)
     return create_op<5>(level, matrix_free);
   else if (n_components == 6)
@@ -160,7 +161,6 @@ create_op(const unsigned int                                  n_components,
     return create_op<11>(level, matrix_free);
   else if (n_components == 12)
     return create_op<12>(level, matrix_free);
-#if 0
   else if (n_components == 13)
     return create_op<13>(level, matrix_free);
   else if (n_components == 14)

--- a/benchmarks/layer_wise.likwid.cc
+++ b/benchmarks/layer_wise.likwid.cc
@@ -413,8 +413,8 @@ test(const Parameters &params, ConvergenceTable &table)
       table.add_value("n_components", n_components);
 
 
-#if false
-    HelmholtzQOperator q_point_operator;
+#if true
+      HelmholtzQOperator q_point_operator;
 #else
       const double        A                      = 16;
       const double        B                      = 1;

--- a/benchmarks/layer_wise.likwid.cc
+++ b/benchmarks/layer_wise.likwid.cc
@@ -1,0 +1,390 @@
+#include <deal.II/base/conditional_ostream.h>
+#include <deal.II/base/convergence_table.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/parameter_handler.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_q_iso_q1.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/mapping_q_cache.h>
+
+#include <deal.II/grid/grid_generator.h>
+
+#include <deal.II/lac/la_parallel_block_vector.h>
+#include <deal.II/lac/la_parallel_vector.h>
+
+#include <deal.II/matrix_free/fe_evaluation.h>
+#include <deal.II/matrix_free/matrix_free.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include "operators.h"
+
+#ifdef LIKWID_PERFMON
+#  include <likwid.h>
+#endif
+
+static unsigned int likwid_counter = 0;
+
+
+using namespace dealii;
+
+struct Parameters
+{
+  unsigned int dim                  = 2;
+  unsigned int n_global_refinements = 1;
+
+  unsigned int fe_degree           = 2;
+  unsigned int n_quadrature_points = 0;
+  unsigned int n_subdivisions      = 1;
+  std::string  fe_type             = "FE_Q";
+
+  unsigned int level = 2;
+
+  unsigned int n_repetitions = 10;
+
+  void
+  parse(const std::string file_name)
+  {
+    dealii::ParameterHandler prm;
+    add_parameters(prm);
+
+    prm.parse_input(file_name, "", true);
+  }
+
+private:
+  void
+  add_parameters(ParameterHandler &prm)
+  {
+    prm.add_parameter("dim", dim);
+    prm.add_parameter("n global refinements", n_global_refinements);
+
+    prm.add_parameter("fe type",
+                      fe_type,
+                      "",
+                      Patterns::Selection("FE_Q|FE_Q_iso_Q1"));
+    prm.add_parameter("fe degree", fe_degree);
+    prm.add_parameter("n quadrature points", n_quadrature_points);
+    prm.add_parameter("n subdivisions", n_subdivisions);
+
+    prm.add_parameter("level", level);
+
+    prm.add_parameter("n repetitions", n_repetitions);
+  }
+};
+
+template <int dim>
+class RightHandSide : public Function<dim>
+{
+public:
+  RightHandSide(const unsigned int component)
+    : component(component)
+  {}
+
+
+  virtual double
+  value(const Point<dim> &p, const unsigned int = 0) const override
+  {
+    if (component == 0)
+      return p[0];
+    else
+      return 0.0;
+  }
+
+private:
+  const unsigned int component;
+};
+
+template <int n_components,
+          int dim,
+          typename Number,
+          typename VectorizedArrayType>
+std::shared_ptr<ProjectionOperatorBase<Number>>
+create_op(const unsigned int                                  level,
+          const MatrixFree<dim, Number, VectorizedArrayType> &matrix_free)
+{
+  const auto &si = matrix_free.get_shape_info().data.front();
+
+  const unsigned int fe_degree     = si.fe_degree;
+  const unsigned int n_q_points_1d = si.n_q_points_1d;
+
+  if ((fe_degree == 1) && (n_q_points_1d == 2))
+    return std::make_shared<
+      ProjectionOperator<dim, 1, 2, n_components, Number, VectorizedArrayType>>(
+      matrix_free, level);
+  if ((fe_degree == 2) && (n_q_points_1d == 4))
+    return std::make_shared<
+      ProjectionOperator<dim, 2, 4, n_components, Number, VectorizedArrayType>>(
+      matrix_free, level);
+  if ((fe_degree == 3) && (n_q_points_1d == 6))
+    return std::make_shared<
+      ProjectionOperator<dim, 3, 6, n_components, Number, VectorizedArrayType>>(
+      matrix_free, level);
+
+  AssertThrow(false, ExcNotImplemented());
+
+  return std::make_shared<
+    ProjectionOperator<dim, -1, 0, n_components, Number, VectorizedArrayType>>(
+    matrix_free, level);
+}
+
+template <int dim, typename Number, typename VectorizedArrayType>
+std::shared_ptr<ProjectionOperatorBase<Number>>
+create_op(const unsigned int                                  n_components,
+          const unsigned int                                  level,
+          const MatrixFree<dim, Number, VectorizedArrayType> &matrix_free)
+{
+  if (n_components == 1)
+    return create_op<1>(level, matrix_free);
+  else if (n_components == 2)
+    return create_op<2>(level, matrix_free);
+  else if (n_components == 3)
+    return create_op<3>(level, matrix_free);
+  else if (n_components == 4)
+    return create_op<4>(level, matrix_free);
+  else if (n_components == 5)
+    return create_op<5>(level, matrix_free);
+  else if (n_components == 6)
+    return create_op<6>(level, matrix_free);
+  else if (n_components == 7)
+    return create_op<7>(level, matrix_free);
+  else if (n_components == 8)
+    return create_op<8>(level, matrix_free);
+  else if (n_components == 9)
+    return create_op<9>(level, matrix_free);
+  else if (n_components == 10)
+    return create_op<10>(level, matrix_free);
+  else if (n_components == 11)
+    return create_op<11>(level, matrix_free);
+  else if (n_components == 12)
+    return create_op<12>(level, matrix_free);
+#if 0
+  else if (n_components == 13)
+    return create_op<13>(level, matrix_free);
+  else if (n_components == 14)
+    return create_op<14>(level, matrix_free);
+  else if (n_components == 15)
+    return create_op<15>(level, matrix_free);
+  else if (n_components == 16)
+    return create_op<16>(level, matrix_free);
+#endif
+
+  AssertThrow(false, ExcNotImplemented());
+
+  return create_op<1>(level, matrix_free);
+}
+
+template <int dim, typename Number, typename VectorizedArrayType>
+void
+test(const Parameters &params, ConvergenceTable &table)
+{
+  using VectorType      = LinearAlgebra::distributed::Vector<Number>;
+  using BlockVectorType = LinearAlgebra::distributed::BlockVector<Number>;
+
+  const auto fe_type              = params.fe_type;
+  const auto fe_degree            = params.fe_degree;
+  const auto n_subdivisions       = params.n_subdivisions;
+  const auto n_global_refinements = params.n_global_refinements;
+  const auto print_l2_norm        = false;
+
+  std::unique_ptr<FiniteElement<dim>> fe;
+  std::unique_ptr<Quadrature<dim>>    quadrature;
+  MappingQ1<dim>                      mapping_q1;
+
+  ConditionalOStream pcout(std::cout,
+                           Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) ==
+                             0);
+
+  if (fe_type == "FE_Q")
+    {
+      AssertThrow(n_subdivisions == 1, ExcInternalError());
+
+      fe = std::make_unique<FE_Q<dim>>(fe_degree);
+
+      const unsigned int n_quadrature_points = params.n_quadrature_points > 0 ?
+                                                 params.n_quadrature_points :
+                                                 (fe_degree + 1);
+
+      quadrature = std::make_unique<QGauss<dim>>(n_quadrature_points);
+    }
+  else if (fe_type == "FE_Q_iso_Q1")
+    {
+      AssertThrow(fe_degree == 1, ExcInternalError());
+
+      fe = std::make_unique<FE_Q_iso_Q1<dim>>(n_subdivisions);
+      quadrature =
+        std::make_unique<QIterated<dim>>(QGauss<1>(2), n_subdivisions);
+    }
+  else
+    {
+      AssertThrow(false, ExcNotImplemented());
+    }
+
+
+  parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD);
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(n_global_refinements);
+
+  DoFHandler<dim> dof_handler(tria);
+  dof_handler.distribute_dofs(*fe);
+
+  AffineConstraints<Number> constraints;
+
+  MappingQCache<dim> mapping(1);
+
+
+  mapping.initialize(
+    mapping_q1,
+    tria,
+    [](const auto &, const auto &point) {
+      Point<dim> result;
+
+      if (true) // TODO
+        return result;
+
+      for (unsigned int d = 0; d < dim; ++d)
+        result[d] = std::sin(2 * numbers::PI * point[(d + 1) % dim]) *
+                    std::sin(numbers::PI * point[d]) * 0.01;
+
+      return result;
+    },
+    true);
+
+  typename MatrixFree<dim, Number, VectorizedArrayType>::AdditionalData
+    additional_data;
+  additional_data.overlap_communication_computation = false;
+
+  MatrixFree<dim, Number, VectorizedArrayType> matrix_free;
+  matrix_free.reinit(
+    mapping, dof_handler, constraints, *quadrature, additional_data);
+
+  const auto run = [&](const auto fu) {
+    // warm up
+    for (unsigned int i = 0; i < 10; ++i)
+      fu();
+
+#ifdef LIKWID_PERFMON
+    const auto add_padding = [](const int value) -> std::string {
+      if (value < 10)
+        return "000" + std::to_string(value);
+      if (value < 100)
+        return "00" + std::to_string(value);
+      if (value < 1000)
+        return "0" + std::to_string(value);
+      if (value < 10000)
+        return "" + std::to_string(value);
+
+      AssertThrow(false, ExcInternalError());
+
+      return "";
+    };
+
+    const std::string likwid_label =
+      "likwid_" + add_padding(likwid_counter); // TODO
+    likwid_counter++;
+#endif
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+#ifdef LIKWID_PERFMON
+    LIKWID_MARKER_START(likwid_label.c_str());
+#endif
+
+    const auto timer = std::chrono::system_clock::now();
+
+    for (unsigned int i = 0; i < params.n_repetitions; ++i)
+      fu();
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+#ifdef LIKWID_PERFMON
+    LIKWID_MARKER_STOP(likwid_label.c_str());
+#endif
+
+    const double time = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                          std::chrono::system_clock::now() - timer)
+                          .count() /
+                        1e9;
+
+    return time;
+  };
+
+  for (unsigned int n_components = 1; n_components <= 12; ++n_components)
+    {
+      table.add_value("dim", dim);
+      table.add_value("fe_type", fe_type);
+      table.add_value("fe_degree", fe_degree);
+      table.add_value("n_quadrature_points",
+                      quadrature->get_tensor_basis()[0].size());
+      table.add_value("n_subdivisions", n_subdivisions);
+      table.add_value("n_global_refinements", n_global_refinements);
+      table.add_value("n_repetitions", params.n_repetitions);
+      table.add_value("n_dofs", dof_handler.n_dofs());
+      table.add_value("n_components", n_components);
+
+      // version 2: vectorial (block system)
+      const auto projection_operator =
+        create_op(n_components, params.level, matrix_free);
+
+      BlockVectorType src, dst;
+      projection_operator->initialize_dof_vector(src);
+      projection_operator->initialize_dof_vector(dst);
+
+      for (unsigned int i = 0; i < n_components; ++i)
+        VectorTools::interpolate(dof_handler,
+                                 RightHandSide<dim>(i),
+                                 src.block(i));
+
+      unsigned int counter = 0;
+
+      const auto time = run([&]() {
+        projection_operator->vmult(dst, src);
+
+        if (print_l2_norm && (counter++ == 0))
+          pcout << dst.l2_norm() << std::endl;
+      });
+
+      table.add_value("t_vector", time / n_components);
+      table.set_scientific("t_vector", true);
+    }
+}
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+#ifdef LIKWID_PERFMON
+  LIKWID_MARKER_INIT;
+  LIKWID_MARKER_THREADINIT;
+#endif
+
+  AssertThrow(argc >= 2, ExcInternalError());
+
+  ConvergenceTable table;
+
+  using Number              = double;
+  using VectorizedArrayType = VectorizedArray<Number>;
+
+  for (int i = 1; i < argc; ++i)
+    {
+      Parameters params;
+      params.parse(std::string(argv[i]));
+
+      if (params.dim == 2)
+        test<2, Number, VectorizedArrayType>(params, table);
+      else if (params.dim == 3)
+        test<3, Number, VectorizedArrayType>(params, table);
+      else
+        AssertThrow(false, ExcNotImplemented());
+    }
+
+  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+    table.write_text(std::cout, TableHandler::TextOutputFormat::org_mode_table);
+
+#ifdef LIKWID_PERFMON
+  LIKWID_MARKER_CLOSE;
+#endif
+}

--- a/benchmarks/layer_wise_00.json
+++ b/benchmarks/layer_wise_00.json
@@ -1,8 +1,8 @@
 {
-  "dim" : 3,
-  "n global refinements" : 8,
-  "fe degree" : 1,
-  "n subdivisions" : 1,
-  "fe type" : "FE_Q",
-  "level" : 5
+    "dim": 3,
+    "n global refinements": 8,
+    "fe degree": 1,
+    "n subdivisions": 1,
+    "fe type": "FE_Q",
+    "level": 5
 }

--- a/benchmarks/layer_wise_00.json
+++ b/benchmarks/layer_wise_00.json
@@ -1,0 +1,8 @@
+{
+  "dim" : 3,
+  "n global refinements" : 8,
+  "fe degree" : 1,
+  "n subdivisions" : 1,
+  "fe type" : "FE_Q",
+  "level" : 5
+}

--- a/benchmarks/layer_wise_01.json
+++ b/benchmarks/layer_wise_01.json
@@ -1,0 +1,8 @@
+{
+    "dim": 3,
+    "n global refinements": 7,
+    "fe degree": 1,
+    "n subdivisions": 2,
+    "fe type": "FE_Q_iso_Q1",
+    "level": 5
+}

--- a/benchmarks/layer_wise_02.json
+++ b/benchmarks/layer_wise_02.json
@@ -4,5 +4,5 @@
     "fe degree": 1,
     "n subdivisions": 1,
     "fe type": "FE_Q",
-    "level": 2
+    "level": 5
 }

--- a/benchmarks/layer_wise_03.json
+++ b/benchmarks/layer_wise_03.json
@@ -4,5 +4,5 @@
     "fe degree": 1,
     "n subdivisions": 2,
     "fe type": "FE_Q_iso_Q1",
-    "level": 2
+    "level": 5
 }

--- a/benchmarks/operators.h
+++ b/benchmarks/operators.h
@@ -791,8 +791,7 @@ private:
                 grad_in[comp][d] =
                   gradients_quad[(comp * dim + d) * nqp + q_index] * jac[d];
 
-            const auto val_out  = val_in;
-            const auto grad_out = grad_in;
+            const auto [val_out, grad_out] = apply_q(q_index, val_in, grad_in);
 
             for (unsigned int comp = 0; comp < nc; ++comp)
               values_quad[comp * nqp + q_index] = val_out[comp] * JxW;

--- a/benchmarks/operators.h
+++ b/benchmarks/operators.h
@@ -733,8 +733,6 @@ private:
         const auto nqp =
           n_q_points != 0 ? Utilities::pow(n_q_points, dim) : phi.n_q_points;
 
-        Tensor<1, nc, Tensor<1, dim, VectorizedArrayType>> grad;
-
         auto values_quad    = phi.begin_values();
         auto gradients_quad = phi.begin_gradients();
 
@@ -762,6 +760,8 @@ private:
 
             // gradients
             {
+              Tensor<1, nc, Tensor<1, dim, VectorizedArrayType>> grad;
+
               std::array<VectorizedArrayType, dim> jac;
 
               for (unsigned int d = 0; d < dim; ++d)

--- a/benchmarks/operators.h
+++ b/benchmarks/operators.h
@@ -53,7 +53,8 @@ template <int dim,
           int n_q_points,
           int n_components,
           typename Number,
-          typename VectorizedArrayType = VectorizedArray<Number>>
+          typename VectorizedArrayType,
+          typename QPointType>
 class ProjectionOperator : public ProjectionOperatorBase<Number>
 {
 public:
@@ -62,9 +63,11 @@ public:
 
   ProjectionOperator(
     const MatrixFree<dim, Number, VectorizedArrayType> &matrix_free,
+    const QPointType &                                  apply_q,
     unsigned int                                        level = 2)
     : matrix_free(matrix_free)
     , level(level)
+    , apply_q(apply_q)
   {}
 
   void
@@ -734,5 +737,5 @@ private:
 private:
   const MatrixFree<dim, Number, VectorizedArrayType> &matrix_free;
   const unsigned int                                  level;
-  const HelmholtzQOperator                            apply_q;
+  const HelmholtzQOperator &                          apply_q;
 };

--- a/benchmarks/operators.h
+++ b/benchmarks/operators.h
@@ -136,38 +136,9 @@ public:
     vmult_internal(dst, src);
   }
 
-  template <int n_components_>
-  DEAL_II_ALWAYS_INLINE inline std::tuple<
-    Tensor<1, n_components_, VectorizedArrayType>,
-    Tensor<1, n_components_, Tensor<1, dim, VectorizedArrayType>>>
-  apply_q(const unsigned int                                   q,
-          const Tensor<1, n_components_, VectorizedArrayType> &value,
-          const Tensor<1, n_components_, Tensor<1, dim, VectorizedArrayType>>
-            &gradient) const
-  {
-    (void)q;
-
-    return {value, gradient};
-  }
-
-  template <int n_components_>
-  DEAL_II_ALWAYS_INLINE inline std::tuple<
-    Tensor<1, n_components_, VectorizedArrayType>,
-    Tensor<2, n_components_, VectorizedArrayType>>
-  apply_q(const unsigned int                                   q,
-          const Tensor<1, n_components_, VectorizedArrayType> &value,
-          const Tensor<2, n_components_, VectorizedArrayType> &gradient) const
-  {
-    (void)q;
-
-    return {value, gradient};
-  }
-
-  DEAL_II_ALWAYS_INLINE inline std::tuple<VectorizedArrayType,
-                                          Tensor<1, dim, VectorizedArrayType>>
-  apply_q(const unsigned int                         q,
-          const VectorizedArrayType &                value,
-          const Tensor<1, dim, VectorizedArrayType> &gradient) const
+  template <typename T1, typename T2>
+  DEAL_II_ALWAYS_INLINE inline std::tuple<T1, T2>
+  apply_q(const unsigned int q, const T1 &value, const T2 &gradient) const
   {
     (void)q;
 

--- a/benchmarks/operators.h
+++ b/benchmarks/operators.h
@@ -9,6 +9,23 @@
 
 using namespace dealii;
 
+class HelmholtzQOperator
+{
+public:
+  HelmholtzQOperator() = default;
+
+  template <typename T1, typename T2>
+  DEAL_II_ALWAYS_INLINE inline std::tuple<T1, T2>
+  operator()(const unsigned int q, const T1 &value, const T2 &gradient) const
+  {
+    (void)q;
+
+    return {value, gradient};
+  }
+
+private:
+};
+
 template <typename Number>
 class ProjectionOperatorBase
 {
@@ -134,15 +151,6 @@ public:
   vmult(BlockVectorType &dst, const BlockVectorType &src) const override
   {
     vmult_internal(dst, src);
-  }
-
-  template <typename T1, typename T2>
-  DEAL_II_ALWAYS_INLINE inline std::tuple<T1, T2>
-  apply_q(const unsigned int q, const T1 &value, const T2 &gradient) const
-  {
-    (void)q;
-
-    return {value, gradient};
   }
 
   template <typename VT>
@@ -836,4 +844,5 @@ public:
 private:
   const MatrixFree<dim, Number, VectorizedArrayType> &matrix_free;
   const unsigned int                                  level;
+  const HelmholtzQOperator                            apply_q;
 };

--- a/benchmarks/operators.h
+++ b/benchmarks/operators.h
@@ -1,0 +1,845 @@
+#pragma once
+
+#include <deal.II/lac/la_parallel_block_vector.h>
+#include <deal.II/lac/la_parallel_vector.h>
+
+#include <deal.II/matrix_free/fe_evaluation.h>
+#include <deal.II/matrix_free/matrix_free.h>
+#include <deal.II/matrix_free/tools.h>
+
+using namespace dealii;
+
+template <typename Number>
+class ProjectionOperatorBase
+{
+public:
+  using VectorType      = LinearAlgebra::distributed::Vector<Number>;
+  using BlockVectorType = LinearAlgebra::distributed::BlockVector<Number>;
+
+  virtual ~ProjectionOperatorBase() = default;
+
+  virtual void
+  initialize_dof_vector(VectorType &vector) const = 0;
+
+  virtual void
+  initialize_dof_vector(BlockVectorType &vector) const = 0;
+
+  virtual void
+  compute_inverse_diagonal(VectorType &vector) const = 0;
+
+  virtual void
+  compute_inverse_diagonal(BlockVectorType &vector) const = 0;
+
+  virtual void
+  vmult(VectorType &dst, const VectorType &src) const = 0;
+
+  virtual void
+  vmult(BlockVectorType &dst, const BlockVectorType &src) const = 0;
+
+  virtual void
+  rhs(VectorType &dst) const = 0;
+
+  virtual void
+  rhs(BlockVectorType &dst) const = 0;
+
+  virtual void
+  vmult_local(BlockVectorType &dst, const BlockVectorType &src) const = 0;
+};
+
+template <int dim,
+          int fe_degree,
+          int n_q_points,
+          int n_components,
+          typename Number,
+          typename VectorizedArrayType = VectorizedArray<Number>>
+class ProjectionOperator : public ProjectionOperatorBase<Number>
+{
+public:
+  using VectorType      = LinearAlgebra::distributed::Vector<Number>;
+  using BlockVectorType = LinearAlgebra::distributed::BlockVector<Number>;
+
+  ProjectionOperator(
+    const MatrixFree<dim, Number, VectorizedArrayType> &matrix_free,
+    unsigned int                                        level = 2)
+    : matrix_free(matrix_free)
+    , level(level)
+  {}
+
+  void
+  initialize_dof_vector(VectorType &vector) const override
+  {
+    matrix_free.initialize_dof_vector(vector);
+  }
+
+  void
+  initialize_dof_vector(BlockVectorType &vector) const override
+  {
+    vector.reinit(n_components);
+
+    for (unsigned int b = 0; b < n_components; ++b)
+      matrix_free.initialize_dof_vector(vector.block(b));
+  }
+
+  void
+  compute_inverse_diagonal(VectorType &diagonal) const override
+  {
+    matrix_free.initialize_dof_vector(diagonal);
+
+    MatrixFreeTools::compute_diagonal(matrix_free,
+                                      diagonal,
+                                      &ProjectionOperator::do_vmult_cell,
+                                      this);
+
+    for (auto &i : diagonal)
+      i = (std::abs(i) > 1.0e-10) ? (1.0 / i) : 1.0;
+  }
+
+  void
+  compute_inverse_diagonal(BlockVectorType &vector) const override
+  {
+    vector.reinit(n_components);
+
+    for (unsigned int b = 0; b < n_components; ++b)
+      matrix_free.initialize_dof_vector(vector.block(b));
+
+    vector = 1.0; // TODO
+  }
+
+  void
+  do_vmult_cell(FEEvaluation<dim,
+                             fe_degree,
+                             n_q_points,
+                             n_components,
+                             Number,
+                             VectorizedArrayType> &phi) const
+  {
+    phi.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
+
+    for (unsigned int q_index = 0; q_index < phi.n_q_points; ++q_index)
+      {
+        phi.submit_value(phi.get_value(q_index), q_index);
+        phi.submit_gradient(phi.get_gradient(q_index), q_index);
+      }
+
+    phi.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
+  }
+
+  void
+  vmult(VectorType &dst, const VectorType &src) const override
+  {
+    vmult_internal(dst, src);
+  }
+
+  void
+  vmult(BlockVectorType &dst, const BlockVectorType &src) const override
+  {
+    vmult_internal(dst, src);
+  }
+
+  DEAL_II_ALWAYS_INLINE inline std::tuple<
+    Tensor<1, n_components, VectorizedArrayType>,
+    Tensor<1, n_components, Tensor<1, dim, VectorizedArrayType>>>
+  apply_q(const unsigned int                                  q,
+          const Tensor<1, n_components, VectorizedArrayType> &value,
+          const Tensor<1, n_components, Tensor<1, dim, VectorizedArrayType>>
+            &gradient) const
+  {
+    (void)q;
+
+    return {value, gradient};
+  }
+
+  template <typename VT>
+  void
+  vmult_internal(VT &dst, const VT &src) const
+  {
+    if (level == 4 || level == 5)
+      matrix_free.template cell_loop<VT, VT>(
+        [&](const auto &matrix_free,
+            auto &      dst,
+            const auto &src,
+            const auto  range) {
+          if (dim != 3)
+            return;
+
+          FEEvaluation<dim,
+                       fe_degree,
+                       n_q_points,
+                       n_components,
+                       Number,
+                       VectorizedArrayType>
+            phi(matrix_free);
+
+          const bool use_fe_evaluation = false;
+
+          constexpr unsigned int n_sub    = fe_degree > 0 ? fe_degree : 1;
+          constexpr unsigned int nn       = n_sub + 1;
+          constexpr unsigned int mm       = n_q_points > 0 ? n_q_points : 1;
+          constexpr unsigned int n_points = Utilities::pow(mm, 3);
+          constexpr unsigned int n_lanes  = VectorizedArrayType::size();
+          VectorizedArrayType    dof_values_[n_components * nn * nn * nn] = {};
+          VectorizedArrayType    values_quad[n_points + 1][n_components]  = {};
+          VectorizedArrayType    gradients_z[n_points + 1][n_components]  = {};
+
+          auto dof_values =
+            use_fe_evaluation ? phi.begin_dof_values() : dof_values_;
+
+
+          VectorizedArrayType ttmp_x0[n_components] = {};
+          VectorizedArrayType ttmp_x1[n_components] = {};
+          VectorizedArrayType ttmp_y0[n_components] = {};
+          VectorizedArrayType ttmp_y1[n_components] = {};
+
+          VectorizedArrayType tmp_x0[n_components] = {};
+          VectorizedArrayType tmp_x1[n_components] = {};
+          VectorizedArrayType tmp_y0[n_components] = {};
+          VectorizedArrayType tmp_y1[n_components] = {};
+
+          using value_type = Tensor<1, n_components, VectorizedArrayType>;
+          using gradient_type =
+            Tensor<1, n_components, Tensor<1, dim, VectorizedArrayType>>;
+
+          value_type    value_in_0    = {};
+          gradient_type gradient_in_0 = {};
+
+          const auto &              dof_info = matrix_free.get_dof_info();
+          const VectorizedArrayType val0 =
+            matrix_free.get_shape_info().data.front().shape_values[0];
+          const VectorizedArrayType val1 =
+            matrix_free.get_shape_info().data.front().shape_values[1];
+          const VectorizedArrayType grad = Number(n_sub) / (val0 - val1);
+
+          const auto src_vectors =
+            internal::get_vector_data<n_components>(src, 0, false, 0, &dof_info)
+              .first;
+          const auto dst_vectors =
+            internal::get_vector_data<n_components>(dst, 0, false, 0, &dof_info)
+              .first;
+
+          for (unsigned int cell = range.first; cell < range.second; ++cell)
+            {
+              if (use_fe_evaluation == true)
+                phi.reinit(cell);
+
+              if (use_fe_evaluation == false)
+                {
+                  const unsigned int *dof_indices =
+                    dof_info.dof_indices_interleaved.data() +
+                    dof_info.row_starts[cell * n_lanes].first +
+                    dof_info.component_dof_indices_offset[0][0] * n_lanes;
+                  for (unsigned int iz = 0; iz < nn; ++iz)
+                    {
+                      for (unsigned int i = 0; i < nn * nn;
+                           ++i, dof_indices += n_lanes)
+                        for (unsigned int comp = 0; comp < n_components; ++comp)
+                          dof_values[comp * nn * nn * nn + iz * nn * nn + i]
+                            .gather(src_vectors[comp]->begin(), dof_indices);
+                    }
+                }
+              else
+                {
+                  phi.read_dof_values(src);
+                }
+
+              for (unsigned int iz = 0; iz < nn; ++iz)
+                {
+                  for (unsigned int comp = 0; comp < n_components; ++comp)
+                    {
+                      VectorizedArrayType temp[mm * nn] = {};
+                      for (unsigned int i1 = 0; i1 < nn; ++i1)
+                        {
+                          temp[i1 * mm] =
+                            val0 * dof_values[comp * nn * nn * nn +
+                                              iz * nn * nn + i1 * nn] +
+                            val1 * dof_values[comp * nn * nn * nn +
+                                              iz * nn * nn + i1 * nn + 1];
+                          for (unsigned int i0 = 0; i0 < n_sub - 1; ++i0)
+                            {
+                              const VectorizedArrayType t =
+                                val0 *
+                                dof_values[comp * nn * nn * nn + iz * nn * nn +
+                                           i1 * nn + 1 + i0];
+                              temp[i1 * mm + 2 * i0 + 1] =
+                                t +
+                                val1 * dof_values[comp * nn * nn * nn +
+                                                  iz * nn * nn + i1 * nn + i0];
+                              temp[i1 * mm + 2 * i0 + 2] =
+                                t +
+                                val1 *
+                                  dof_values[comp * nn * nn * nn +
+                                             iz * nn * nn + i1 * nn + i0 + 2];
+                            }
+                          temp[(i1 + 1) * mm - 1] =
+                            val0 *
+                              dof_values[comp * nn * nn * nn + iz * nn * nn +
+                                         (i1 + 1) * nn - 1] +
+                            val1 * dof_values[comp * nn * nn * nn +
+                                              iz * nn * nn + (i1 + 1) * nn - 2];
+                        }
+                      for (unsigned int i1 = 0; i1 < mm; ++i1)
+                        {
+                          const unsigned int i = iz * mm * mm + i1;
+                          values_quad[i][comp] =
+                            val0 * temp[i1] + val1 * temp[i1 + mm];
+                          for (unsigned int i0 = 0; i0 < n_sub - 1; ++i0)
+                            {
+                              const VectorizedArrayType t =
+                                val0 * temp[i1 + (1 + i0) * mm];
+                              values_quad[i + (2 * i0 + 1) * mm][comp] =
+                                t + val1 * temp[i1 + i0 * mm];
+                              values_quad[i + (2 * i0 + 2) * mm][comp] =
+                                t + val1 * temp[i1 + (i0 + 2) * mm];
+                            }
+                          values_quad[i + (mm - 1) * mm][comp] =
+                            val0 * temp[i1 + (nn - 1) * mm] +
+                            val1 * temp[i1 + (nn - 2) * mm];
+                        }
+                    }
+                }
+
+              for (unsigned int i = 0; i < mm * mm; ++i)
+                {
+                  for (unsigned int comp = 0; comp < n_components; ++comp)
+                    {
+                      // work in reverse order because we alias between input
+                      // and output array here
+                      VectorizedArrayType tmp0 =
+                        values_quad[i + (nn - 1) * mm * mm][comp];
+                      VectorizedArrayType tmp1 =
+                        values_quad[i + (nn - 2) * mm * mm][comp];
+                      values_quad[i + (mm - 1) * mm * mm][comp] =
+                        val0 * tmp0 + val1 * tmp1;
+                      for (unsigned int i0 = n_sub - 1; i0 > 0; --i0)
+                        {
+                          const VectorizedArrayType t = val0 * tmp1;
+                          values_quad[i + 2 * i0 * mm * mm][comp] =
+                            t + val1 * tmp0;
+                          const VectorizedArrayType gr =
+                            grad *
+                            (values_quad[i + (2 * i0 + 1) * mm * mm][comp] -
+                             values_quad[i + 2 * i0 * mm * mm][comp]);
+                          gradients_z[i + 2 * i0 * mm * mm][comp]       = gr;
+                          gradients_z[i + (2 * i0 + 1) * mm * mm][comp] = gr;
+                          tmp0                                          = tmp1;
+                          tmp1 = values_quad[i + (i0 - 1) * mm * mm][comp];
+                          values_quad[i + (2 * i0 - 1) * mm * mm][comp] =
+                            t + val1 * tmp1;
+                        }
+                      values_quad[i][comp] = val0 * tmp1 + val1 * tmp0;
+                      const VectorizedArrayType gr =
+                        grad *
+                        (values_quad[i + mm * mm][comp] - values_quad[i][comp]);
+                      gradients_z[i + mm * mm][comp] = gr;
+                      gradients_z[i][comp]           = gr;
+                    }
+                }
+
+              const auto &mapping = matrix_free.get_mapping_info().cell_data[0];
+              const auto  J_value = mapping.JxW_values[0];
+              const auto  jacobian = mapping.jacobians[0][0];
+              const Number quadrature_weight =
+                mapping.descriptor[0].quadrature_weights[0];
+              unsigned int offsets[n_sub * n_sub];
+              for (unsigned int i1 = 0; i1 < n_sub; ++i1)
+                for (unsigned int i0 = 0; i0 < n_sub; ++i0)
+                  offsets[i1 * n_sub + i0] = i1 * mm * 2 + i0 * 2;
+
+              if (level == 4)
+                {
+                  for (unsigned int iz = 0; iz < mm; ++iz)
+                    for (unsigned int el = 0; el < n_sub * n_sub; ++el)
+                      for (unsigned int comp = 0; comp < n_components; ++comp)
+                        {
+                          // Work for all 2x2 quadrature points of a single
+                          // element in a plane to utilize register blocking
+                          // between x and y derivatives
+                          const unsigned int idx = iz * mm * mm + offsets[el];
+                          const VectorizedArrayType gradient_y_0 =
+                            grad * (values_quad[idx + mm][comp] -
+                                    values_quad[idx][comp]);
+                          const VectorizedArrayType gradient_y_1 =
+                            grad * (values_quad[idx + mm + 1][comp] -
+                                    values_quad[idx + 1][comp]);
+                          const VectorizedArrayType gradient_x_0 =
+                            grad * (values_quad[idx + 1][comp] -
+                                    values_quad[idx][comp]);
+                          const VectorizedArrayType gradient_x_1 =
+                            grad * (values_quad[idx + mm + 1][comp] -
+                                    values_quad[idx + mm][comp]);
+
+                          const VectorizedArrayType JxW =
+                            J_value * quadrature_weight;
+                          // In the more general case with coupling between
+                          // components, we would need to switch the loop over
+                          // the inner 4 quadrature points (x-y plane) with the
+                          // loop over components; this will cause register
+                          // spills and increase the pressure on the L1 cache,
+                          // but no other data transfer
+                          values_quad[idx][comp] *= JxW;
+                          values_quad[idx + 1][comp] *= JxW;
+                          values_quad[idx + mm][comp] *= JxW;
+                          values_quad[idx + mm + 1][comp] *= JxW;
+                          gradients_z[idx][comp] *=
+                            JxW * jacobian[2][2] * jacobian[2][2];
+                          gradients_z[idx + 1][comp] *=
+                            JxW * jacobian[2][2] * jacobian[2][2];
+                          gradients_z[idx + mm][comp] *=
+                            JxW * jacobian[2][2] * jacobian[2][2];
+                          gradients_z[idx + mm + 1][comp] *=
+                            JxW * jacobian[2][2] * jacobian[2][2];
+                          // in the more general case, do operations on two y0,
+                          // y1, x0, x1 slots each, so twice the work to be done
+                          // here
+                          const VectorizedArrayType y0 =
+                            gradient_y_0 *
+                            (JxW * jacobian[1][1] * jacobian[1][1]);
+                          const VectorizedArrayType y1 =
+                            gradient_y_1 *
+                            (JxW * jacobian[1][1] * jacobian[1][1]);
+                          const VectorizedArrayType x0 =
+                            gradient_x_0 *
+                            (JxW * jacobian[0][0] * jacobian[0][0]);
+                          const VectorizedArrayType x1 =
+                            gradient_x_1 *
+                            (JxW * jacobian[0][0] * jacobian[0][0]);
+
+                          // Now back to the interpolation operations, which are
+                          // the general ones apart from 'x0 + x0' -> 'x0 + x2'
+                          const VectorizedArrayType tmp_x0 = x0 + x0;
+                          const VectorizedArrayType tmp_x1 = x1 + x1;
+                          const VectorizedArrayType tmp_y0 = y0 + y0;
+                          const VectorizedArrayType tmp_y1 = y1 + y1;
+                          values_quad[idx][comp] -= grad * tmp_x0;
+                          values_quad[idx][comp] -= grad * tmp_y0;
+                          values_quad[idx + 1][comp] += grad * tmp_x0;
+                          values_quad[idx + 1][comp] -= grad * tmp_y1;
+                          values_quad[idx + mm][comp] -= grad * tmp_x1;
+                          values_quad[idx + mm][comp] += grad * tmp_y0;
+                          values_quad[idx + mm + 1][comp] += grad * tmp_x1;
+                          values_quad[idx + mm + 1][comp] += grad * tmp_y1;
+                        }
+                }
+              else
+                {
+                  for (unsigned int iz = 0; iz < mm; ++iz)
+                    for (unsigned int el = 0; el < n_sub * n_sub; ++el)
+                      {
+                        const unsigned int idx = iz * mm * mm + offsets[el];
+                        const VectorizedArrayType JxW =
+                          J_value * quadrature_weight;
+
+                        for (unsigned int comp = 0; comp < n_components; ++comp)
+                          {
+                            ttmp_x0[comp] = (values_quad[idx + 1][comp] -
+                                             values_quad[idx][comp]) *
+                                            (grad * jacobian[0][0]);
+
+                            ttmp_x1[comp] = (values_quad[idx + mm + 1][comp] -
+                                             values_quad[idx + mm][comp]) *
+                                            (grad * jacobian[0][0]);
+
+                            ttmp_y0[comp] = (values_quad[idx + mm][comp] -
+                                             values_quad[idx][comp]) *
+                                            (grad * jacobian[1][1]);
+
+                            ttmp_y1[comp] = (values_quad[idx + mm + 1][comp] -
+                                             values_quad[idx + 1][comp]) *
+                                            (grad * jacobian[1][1]);
+                          }
+
+                        for (unsigned int Q = 0; Q < 4; ++Q)
+                          {
+                            unsigned int idx_ = 0;
+
+                            if (Q == 0)
+                              idx_ = idx;
+                            else if (Q == 1)
+                              idx_ = idx + 1;
+                            else if (Q == 2)
+                              idx_ = idx + mm;
+                            else
+                              idx_ = idx + mm + 1;
+
+                            for (unsigned int comp = 0; comp < n_components;
+                                 ++comp)
+                              {
+                                gradient_in_0[comp][0] =
+                                  (Q / 2 == 0) ? ttmp_x0[comp] : ttmp_x1[comp];
+                                gradient_in_0[comp][1] =
+                                  (Q % 2 == 0) ? ttmp_y0[comp] : ttmp_y1[comp];
+                              }
+
+                            for (unsigned int comp = 0; comp < n_components;
+                                 ++comp)
+                              value_in_0[comp] = values_quad[idx_][comp];
+
+                            for (unsigned int comp = 0; comp < n_components;
+                                 ++comp)
+                              gradient_in_0[comp][2] =
+                                gradients_z[idx_][comp] * jacobian[2][2];
+
+                            const auto [value_out_0, gradient_out_0] =
+                              apply_q(idx_, value_in_0, gradient_in_0);
+
+                            for (unsigned int comp = 0; comp < n_components;
+                                 ++comp)
+                              values_quad[idx_][comp] = value_out_0[comp] * JxW;
+
+                            for (unsigned int comp = 0; comp < n_components;
+                                 ++comp)
+                              gradients_z[idx_][comp] =
+                                gradient_out_0[comp][2] *
+                                (JxW * jacobian[2][2]);
+
+                            for (unsigned int comp = 0; comp < n_components;
+                                 ++comp)
+                              {
+                                const auto x0 = gradient_out_0[comp][0] *
+                                                (JxW * jacobian[0][0]);
+
+                                const auto y0 = gradient_out_0[comp][1] *
+                                                (JxW * jacobian[1][1]);
+
+                                // Now back to the interpolation operations
+                                if (Q == 0)
+                                  {
+                                    tmp_x0[comp] = x0;
+                                    tmp_y0[comp] = y0;
+                                  }
+                                else if (Q == 1)
+                                  {
+                                    tmp_x0[comp] += x0;
+                                    tmp_y1[comp] = y0;
+                                  }
+                                else if (Q == 2)
+                                  {
+                                    tmp_x1[comp] = x0;
+                                    tmp_y0[comp] += y0;
+                                  }
+                                else
+                                  {
+                                    tmp_x1[comp] += x0;
+                                    tmp_y1[comp] += y0;
+                                  }
+                              }
+                          }
+
+                        for (unsigned int comp = 0; comp < n_components; ++comp)
+                          values_quad[idx][comp] +=
+                            (-tmp_x0[comp] - tmp_y0[comp]) * grad;
+
+                        for (unsigned int comp = 0; comp < n_components; ++comp)
+                          values_quad[idx + 1][comp] +=
+                            (+tmp_x0[comp] - tmp_y1[comp]) * grad;
+
+                        for (unsigned int comp = 0; comp < n_components; ++comp)
+                          values_quad[idx + mm][comp] +=
+                            (-tmp_x1[comp] + tmp_y0[comp]) * grad;
+
+                        for (unsigned int comp = 0; comp < n_components; ++comp)
+                          values_quad[idx + mm + 1][comp] +=
+                            (+tmp_x1[comp] + tmp_y1[comp]) * grad;
+                      }
+                }
+
+              for (unsigned int i = 0; i < mm * mm; ++i)
+                {
+                  for (unsigned int comp = 0; comp < n_components; ++comp)
+                    {
+                      const VectorizedArrayType tmp =
+                        gradients_z[i][comp] + gradients_z[i + mm * mm][comp];
+                      VectorizedArrayType tmp0 =
+                        values_quad[i][comp] - grad * tmp;
+                      VectorizedArrayType tmp1 =
+                        values_quad[i + mm * mm][comp] + grad * tmp;
+                      values_quad[i][comp] = val0 * tmp0 + val1 * tmp1;
+                      for (unsigned int i0 = 1; i0 < n_sub; ++i0)
+                        {
+                          VectorizedArrayType sum = val1 * tmp0 + val0 * tmp1;
+                          const VectorizedArrayType tmp =
+                            gradients_z[i + 2 * i0 * mm * mm][comp] +
+                            gradients_z[i + (2 * i0 + 1) * mm * mm][comp];
+                          tmp0 = values_quad[i + 2 * i0 * mm * mm][comp] -
+                                 grad * tmp;
+                          tmp1 = values_quad[i + (2 * i0 + 1) * mm * mm][comp] +
+                                 grad * tmp;
+                          sum += val0 * tmp0;
+                          sum += val1 * tmp1;
+                          values_quad[i + i0 * mm * mm][comp] = sum;
+                        }
+                      values_quad[i + n_sub * mm * mm][comp] =
+                        val1 * tmp0 + val0 * tmp1;
+                    }
+                }
+
+              for (unsigned int iz = 0; iz < nn; ++iz)
+                {
+                  for (unsigned int comp = 0; comp < n_components; ++comp)
+                    {
+                      VectorizedArrayType temp[mm * nn] = {};
+                      for (unsigned int i1 = 0; i1 < mm; ++i1)
+                        {
+                          const unsigned int  i    = iz * mm * mm + i1;
+                          VectorizedArrayType tmp0 = values_quad[i][comp];
+                          VectorizedArrayType tmp1 = values_quad[i + mm][comp];
+                          temp[i1]                 = val0 * tmp0 + val1 * tmp1;
+                          for (unsigned int i0 = 1; i0 < n_sub; ++i0)
+                            {
+                              VectorizedArrayType sum =
+                                val1 * tmp0 + val0 * tmp1;
+                              tmp0 = values_quad[i + 2 * i0 * mm][comp];
+                              tmp1 = values_quad[i + (2 * i0 + 1) * mm][comp];
+                              sum += val0 * tmp0;
+                              sum += val1 * tmp1;
+                              temp[i1 + i0 * mm] = sum;
+                            }
+                          temp[i1 + n_sub * mm] = val1 * tmp0 + val0 * tmp1;
+                        }
+                      for (unsigned int i1 = 0; i1 < nn; ++i1)
+                        {
+                          VectorizedArrayType tmp0 = temp[i1 * mm];
+                          VectorizedArrayType tmp1 = temp[i1 * mm + 1];
+                          dof_values[comp * nn * nn * nn + iz * nn * nn +
+                                     i1 * nn]      = val0 * tmp0 + val1 * tmp1;
+                          for (unsigned int i0 = 1; i0 < n_sub; ++i0)
+                            {
+                              VectorizedArrayType sum =
+                                val1 * tmp0 + val0 * tmp1;
+                              tmp0 = temp[i1 * mm + 2 * i0];
+                              tmp1 = temp[i1 * mm + 2 * i0 + 1];
+                              sum += val0 * tmp0;
+                              sum += val1 * tmp1;
+                              dof_values[comp * nn * nn * nn + iz * nn * nn +
+                                         i1 * nn + i0] = sum;
+                            }
+                          dof_values[comp * nn * nn * nn + iz * nn * nn +
+                                     i1 * nn + n_sub] =
+                            val1 * tmp0 + val0 * tmp1;
+                        }
+                    }
+                }
+
+              if (use_fe_evaluation == false)
+                {
+                  const unsigned int *dof_indices =
+                    dof_info.dof_indices_interleaved.data() +
+                    dof_info.row_starts[cell * n_lanes].first +
+                    dof_info.component_dof_indices_offset[0][0] * n_lanes;
+
+                  for (unsigned int iz = 0; iz < nn; ++iz)
+                    {
+                      for (unsigned int i = 0; i < nn * nn;
+                           ++i, dof_indices += n_lanes)
+                        for (unsigned int comp = 0; comp < n_components; ++comp)
+                          {
+#if DEAL_II_VECTORIZATION_WIDTH_IN_BITS < 512
+                            for (unsigned int v = 0; v < n_lanes; ++v)
+                              (*dst_vectors[comp])
+                                .local_element(dof_indices[v]) +=
+                                dof_values[comp * nn * nn * nn + iz * nn * nn +
+                                           i][v];
+#else
+                            // only use gather in case there is also scatter.
+                            VectorizedArrayType tmp = {};
+                            tmp.gather(dst_vectors[comp]->begin(), dof_indices);
+                            tmp += dof_values[comp * nn * nn * nn +
+                                              iz * nn * nn + i];
+                            tmp.scatter(dof_indices,
+                                        dst_vectors[comp]->begin());
+#endif
+                          }
+                    }
+                }
+              else
+                {
+                  phi.distribute_local_to_global(dst);
+                }
+            }
+        },
+        dst,
+        src,
+        true);
+    else
+      matrix_free.template cell_loop<VT, VT>(
+        [this](const auto &matrix_free,
+               auto &      dst,
+               const auto &src,
+               const auto  range) {
+          FEEvaluation<dim,
+                       fe_degree,
+                       n_q_points,
+                       n_components,
+                       Number,
+                       VectorizedArrayType>
+            phi(matrix_free, range);
+
+          for (unsigned int cell = range.first; cell < range.second; ++cell)
+            {
+              phi.reinit(cell);
+
+              op_local(phi, dst, src);
+            }
+        },
+        dst,
+        src,
+        true);
+  }
+
+  void
+  vmult_local(BlockVectorType &dst, const BlockVectorType &src) const override
+  {
+    matrix_free.template cell_loop<BlockVectorType, BlockVectorType>(
+      [this](
+        const auto &matrix_free, auto &dst, const auto &src, const auto range) {
+        FEEvaluation<dim, fe_degree, n_q_points, 1, Number, VectorizedArrayType>
+          phi(matrix_free, range);
+
+        for (unsigned int cell = range.first; cell < range.second; ++cell)
+          {
+            phi.reinit(cell);
+
+            for (unsigned int b = 0; b < n_components; ++b)
+              op_local(phi, dst.block(b), src.block(b));
+          }
+      },
+      dst,
+      src,
+      true);
+  }
+
+private:
+  template <int nc, typename VT>
+  void
+  op_local(
+    FEEvaluation<dim, fe_degree, n_q_points, nc, Number, VectorizedArrayType>
+      &       phi,
+    VT &      dst,
+    const VT &src) const
+  {
+    if (level == 0)
+      phi.read_dof_values(src);
+    else
+      phi.gather_evaluate(src,
+                          EvaluationFlags::values | EvaluationFlags::gradients);
+
+    if (level == 2)
+      for (unsigned int q_index = 0; q_index < phi.n_q_points; ++q_index)
+        {
+          phi.submit_value(phi.get_value(q_index), q_index);
+          phi.submit_gradient(phi.get_gradient(q_index), q_index);
+        }
+    else if (level == 3)
+      {
+        const auto nqp =
+          n_q_points != 0 ? Utilities::pow(n_q_points, dim) : phi.n_q_points;
+
+        Tensor<1, nc, Tensor<1, dim, VectorizedArrayType>> grad;
+
+        auto values_quad    = phi.begin_values();
+        auto gradients_quad = phi.begin_gradients();
+
+        const auto &mapping = matrix_free.get_mapping_info().cell_data[0];
+        const auto  quadrature_weights =
+          mapping.descriptor[0].quadrature_weights.begin();
+        const auto J_value  = mapping.JxW_values.begin();
+        const auto jacobian = mapping.jacobians[0].begin();
+
+        for (unsigned int q_index = 0; q_index < nqp; ++q_index)
+          {
+            const VectorizedArrayType JxW =
+              J_value[0] * quadrature_weights[q_index];
+
+            // values
+            {
+              // get_value
+              Tensor<1, nc, VectorizedArrayType> val;
+              for (unsigned int comp = 0; comp < nc; ++comp)
+                val[comp] = values_quad[comp * nqp + q_index];
+
+              for (unsigned int comp = 0; comp < nc; ++comp)
+                values_quad[comp * nqp + q_index] = val[comp] * JxW;
+            }
+
+            // gradients
+            {
+              std::array<VectorizedArrayType, dim> jac;
+
+              for (unsigned int d = 0; d < dim; ++d)
+                jac[d] = jacobian[0][d][d];
+
+              for (unsigned int d = 0; d < dim; ++d)
+                for (unsigned int comp = 0; comp < nc; ++comp)
+                  grad[comp][d] =
+                    gradients_quad[(comp * dim + d) * nqp + q_index] * jac[d];
+
+              for (unsigned int d = 0; d < dim; ++d)
+                {
+                  const VectorizedArrayType factor = jac[d] * JxW;
+                  for (unsigned int comp = 0; comp < nc; ++comp)
+                    gradients_quad[(comp * dim + d) * nqp + q_index] =
+                      grad[comp][d] * factor;
+                }
+            }
+          }
+      }
+
+    if (level == 0)
+      phi.distribute_local_to_global(dst);
+    else
+      phi.integrate_scatter(EvaluationFlags::values |
+                              EvaluationFlags::gradients,
+                            dst);
+  }
+
+public:
+  void
+  rhs(VectorType &dst) const override
+  {
+    rhs_internal(dst);
+  }
+
+  void
+  rhs(BlockVectorType &dst) const override
+  {
+    rhs_internal(dst);
+  }
+
+  template <typename VT>
+  void
+  rhs_internal(VT &dst) const
+  {
+    double dummy = 0.;
+    matrix_free.template cell_loop<VT, double>(
+      [](const auto &matrix_free, auto &dst, const auto &, const auto range) {
+        FEEvaluation<dim,
+                     fe_degree,
+                     n_q_points,
+                     n_components,
+                     Number,
+                     VectorizedArrayType>
+          phi(matrix_free, range);
+
+        for (unsigned int cell = range.first; cell < range.second; ++cell)
+          {
+            phi.reinit(cell);
+
+            for (unsigned int q_index = 0; q_index < phi.n_q_points; ++q_index)
+              {
+                if constexpr (n_components == 1)
+                  phi.submit_value(VectorizedArrayType(1.0), q_index);
+                else
+                  AssertThrow(false, ExcNotImplemented());
+              }
+
+            phi.integrate_scatter(EvaluationFlags::values, dst);
+          }
+      },
+      dst,
+      dummy,
+      true);
+  }
+
+private:
+  const MatrixFree<dim, Number, VectorizedArrayType> &matrix_free;
+  const unsigned int                                  level;
+};

--- a/benchmarks/operators.h
+++ b/benchmarks/operators.h
@@ -737,5 +737,5 @@ private:
 private:
   const MatrixFree<dim, Number, VectorizedArrayType> &matrix_free;
   const unsigned int                                  level;
-  const HelmholtzQOperator &                          apply_q;
+  const QPointType &                                  apply_q;
 };


### PR DESCRIPTION
Helmholtz-Operator with `FEValues` (first two columns) and `FEEvaluation` (third column) on a Cartesian mesh (40 procs):

```
| dim | fe_type | n_dofs  | n_components | t_0        | t_1        | t_2        | 
| 3   | FE_Q    | 2146689 | 1            | 5.8874e-02 | 1.2177e-01 | 3.4334e-03 | 
| 3   | FE_Q    | 4293378 | 2            | 1.2809e-01 | 2.4782e-01 | 6.1621e-03 | 
| 3   | FE_Q    | 6440067 | 3            | 1.9842e-01 | 3.6287e-01 | 1.0750e-02 | 
| 3   | FE_Q    | 8586756 | 4            | 3.0696e-01 | 4.4631e-01 | 1.2051e-02 |
```

One can see speedups of factor 17-25. For 2D the values are somewhat lower but not much.