### PR TITLE
Use control box in surface computations

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/driver.h
+++ b/applications/sintering/include/pf-applications/sintering/driver.h
@@ -2836,6 +2836,7 @@ namespace Sintering
             iso_value,
             output,
             sintering_operator.n_grains(),
+            gb_lim,
             params.output_data.n_coarsening_steps);
         }
 

--- a/applications/sintering/include/pf-applications/sintering/postprocessors.h
+++ b/applications/sintering/include/pf-applications/sintering/postprocessors.h
@@ -731,6 +731,7 @@ namespace Sintering
                                               vector,
                                               iso_level,
                                               n_grains,
+                                              gb_lim,
                                               n_coarsening_steps,
                                               n_subdivisions,
                                               tolerance);


### PR DESCRIPTION
Not only when the integrals are evaluated but also for the case iso surface computations.

Additionally, I also modified the detection of the grain boundary: the new algo from #488 works nicely in most of the cases except from the very symmetric ones, there an old determination with a threshold works better. So I have basically combined both.