### PR TITLE
Use filter bounding box for surface and grain boundary contours

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/driver.h
+++ b/applications/sintering/include/pf-applications/sintering/driver.h
@@ -2873,7 +2873,8 @@ namespace Sintering
             output,
             sintering_operator.n_grains(),
             gb_lim,
-            params.output_data.n_coarsening_steps);
+            params.output_data.n_coarsening_steps,
+            box_filter);
         }
 
       if (params.output_data.contours_tex)

--- a/applications/sintering/include/pf-applications/sintering/driver.h
+++ b/applications/sintering/include/pf-applications/sintering/driver.h
@@ -2817,20 +2817,22 @@ namespace Sintering
              */
             int point_location = -1;
 
-            for (unsigned int d = 0; d < dim; ++d)
+            if (control_box.point_inside(p))
               {
-                if (std::abs(control_box.lower_bound(d) - p[d]) <
-                      std::numeric_limits<Number>::epsilon() ||
-                    std::abs(control_box.upper_bound(d) - p[d]) <
-                      std::numeric_limits<Number>::epsilon())
+                point_location = 1;
+
+                for (unsigned int d = 0; d < dim; ++d)
                   {
-                    point_location = 0;
-                    break;
+                    if (std::abs(control_box.lower_bound(d) - p[d]) <
+                          std::numeric_limits<Number>::epsilon() ||
+                        std::abs(control_box.upper_bound(d) - p[d]) <
+                          std::numeric_limits<Number>::epsilon())
+                      {
+                        point_location = 0;
+                        break;
+                      }
                   }
               }
-
-            if (point_location != 0 && control_box.point_inside(p))
-              point_location = 1;
 
             return point_location;
           };

--- a/applications/sintering/include/pf-applications/sintering/postprocessors.h
+++ b/applications/sintering/include/pf-applications/sintering/postprocessors.h
@@ -168,8 +168,16 @@ namespace Sintering
         const DoFHandler<dim> &                background_dof_handler,
         VectorType &                           vector,
         const double                           iso_level,
-        std::function<int(const Point<dim> &)> box_filter)
+        std::function<int(const Point<dim> &)> box_filter,
+        const double                           null_value = 0.)
       {
+        AssertThrow(std::abs(iso_level - null_value) >
+                      std::numeric_limits<Number>::epsilon(),
+                    ExcMessage(
+                      "iso_level = " + std::to_string(iso_level) +
+                      " and null_value = " + std::to_string(null_value) +
+                      " have to be different"));
+
         const auto &  fe = background_dof_handler.get_fe();
         FEValues<dim> fe_values(mapping,
                                 fe,
@@ -199,7 +207,7 @@ namespace Sintering
                     if (pred_status == 0)
                       global_dof_value = std::min(global_dof_value, iso_level);
                     else if (pred_status == -1)
-                      global_dof_value = 0.;
+                      global_dof_value = null_value;
                   }
               }
           }

--- a/applications/sintering/include/pf-applications/sintering/postprocessors.h
+++ b/applications/sintering/include/pf-applications/sintering/postprocessors.h
@@ -162,6 +162,52 @@ namespace Sintering
       }
 
       template <int dim, typename VectorType>
+      void
+      filter_mesh_withing_bounding_box(
+        const Mapping<dim> &                   mapping,
+        const DoFHandler<dim> &                background_dof_handler,
+        VectorType &                           vector,
+        const double                           iso_level,
+        const unsigned int                     n_grains,
+        std::function<int(const Point<dim> &)> box_filter)
+      {
+        const auto &  fe = background_dof_handler.get_fe();
+        FEValues<dim> fe_values(mapping,
+                                fe,
+                                fe.get_unit_support_points(),
+                                update_quadrature_points);
+
+        std::vector<types::global_dof_index> dof_indices(fe.n_dofs_per_cell());
+
+        for (const auto &cell : background_dof_handler.active_cell_iterators())
+          {
+            if (!cell->is_locally_owned())
+              continue;
+
+            cell->get_dof_indices(dof_indices);
+
+            fe_values.reinit(cell);
+
+            for (unsigned int b = 0; b < n_grains; ++b)
+              {
+                const auto &points = fe_values.get_quadrature_points();
+
+                for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
+                  {
+                    const int pred_status = box_filter(points[i]);
+
+                    auto &global_dof_value =
+                      vector.block(b + 2)[dof_indices[i]];
+                    if (pred_status == 0)
+                      global_dof_value = std::min(global_dof_value, iso_level);
+                    else if (pred_status == -1)
+                      global_dof_value = 0.;
+                  }
+              }
+          }
+      }
+
+      template <int dim, typename VectorType>
       bool
       build_grain_boundaries_mesh(Triangulation<dim - 1, dim> &tria,
                                   const Mapping<dim> &         mapping,
@@ -532,7 +578,7 @@ namespace Sintering
 
       if (box_filter)
         {
-          // Copy vector if not doen before
+          // Copy vector if not done before
           if (n_coarsening_steps == 0)
             {
               solution_dealii = vector;
@@ -540,42 +586,13 @@ namespace Sintering
               vector_to_be_used = &solution_dealii;
             }
 
-          const auto &  fe = background_dof_handler_to_be_used->get_fe();
-          FEValues<dim> fe_values(mapping,
-                                  fe,
-                                  fe.get_unit_support_points(),
-                                  update_quadrature_points);
-
-          std::vector<types::global_dof_index> dof_indices(
-            fe.n_dofs_per_cell());
-
-          for (const auto &cell :
-               background_dof_handler_to_be_used->active_cell_iterators())
-            {
-              if (!cell->is_locally_owned())
-                continue;
-
-              cell->get_dof_indices(dof_indices);
-
-              fe_values.reinit(cell);
-
-              for (unsigned int b = 0; b < n_grains; ++b)
-                {
-                  const auto &points = fe_values.get_quadrature_points();
-
-                  for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
-                    {
-                      const int pred_status = box_filter(points[i]);
-
-                      auto &global_dof_value =
-                        solution_dealii.block(b + 2)[dof_indices[i]];
-                      if (pred_status == 0)
-                        global_dof_value = std::min(global_dof_value, 0.5);
-                      else if (pred_status == -1)
-                        global_dof_value = 0.;
-                    }
-                }
-            }
+          internal::filter_mesh_withing_bounding_box(
+            mapping,
+            *background_dof_handler_to_be_used,
+            solution_dealii,
+            iso_level,
+            n_grains,
+            box_filter);
         }
 
 

--- a/applications/sintering/include/pf-applications/sintering/postprocessors.h
+++ b/applications/sintering/include/pf-applications/sintering/postprocessors.h
@@ -172,7 +172,7 @@ namespace Sintering
         const double                           null_value = 0.)
       {
         AssertThrow(std::abs(iso_level - null_value) >
-                      std::numeric_limits<Number>::epsilon(),
+                      std::numeric_limits<double>::epsilon(),
                     ExcMessage(
                       "iso_level = " + std::to_string(iso_level) +
                       " and null_value = " + std::to_string(null_value) +


### PR DESCRIPTION
This is in order to make images like this:
![image](https://user-images.githubusercontent.com/8836201/221830489-ba412d3e-82af-448c-8519-7d190ba27c3d.png)
The most coarse mesh has to adjusted to fit the bounding box boundaries if one wants to have a perfect flat cut plane without "steps".

This PR has to be rebased after #489 is merged