### PR TITLE
Radius buffer for clouds initial coloring

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/initial_values_cloud.h
+++ b/applications/sintering/include/pf-applications/sintering/initial_values_cloud.h
@@ -18,7 +18,8 @@ namespace Sintering
     InitialValuesCloud(const std::vector<Particle<dim>> &particles_in,
                        const double                      interface_width,
                        const bool   minimize_order_parameters,
-                       const double interface_buffer_ratio = 0.5)
+                       const double interface_buffer_ratio = 0.5,
+                       const double radius_buffer_ratio    = 0.0)
       : InitialValues<dim>()
       , particles(particles_in)
       , interface_width(interface_width)
@@ -162,7 +163,8 @@ namespace Sintering
                   if (minimize_order_parameters)
                     {
                       double buffer = interface_width +
-                                      interface_buffer_ratio * interface_width;
+                                      interface_buffer_ratio * interface_width +
+                                      radius_buffer_ratio * std::max(r1, r2);
                       if (distance <= dist_max + buffer)
                         {
                           dsp.add(i, j);

--- a/applications/sintering/include/pf-applications/sintering/parameters.h
+++ b/applications/sintering/include/pf-applications/sintering/parameters.h
@@ -39,6 +39,7 @@ namespace Sintering
     double          interface_width                    = 2.0;
     bool            minimize_order_parameters          = true;
     double          interface_buffer_ratio             = 1.0;
+    double          radius_buffer_ratio                = 0.0;
     bool            periodic                           = false;
     bool            custom_bounding_box                = false;
     bool            custom_divisions                   = false;
@@ -430,6 +431,9 @@ namespace Sintering
       prm.add_parameter("InterfaceBufferRatio",
                         geometry_data.interface_buffer_ratio,
                         "Interface buffer ratio.");
+      prm.add_parameter("RadiusBufferRatio",
+                        geometry_data.radius_buffer_ratio,
+                        "Max radius based buffer ratio.");
       prm.add_parameter("Periodic",
                         geometry_data.periodic,
                         "Is domain periodic.");

--- a/applications/sintering/sintering.cc
+++ b/applications/sintering/sintering.cc
@@ -249,7 +249,8 @@ main(int argc, char **argv)
           particles,
           params.geometry_data.interface_width,
           params.geometry_data.minimize_order_parameters,
-          params.geometry_data.interface_buffer_ratio);
+          params.geometry_data.interface_buffer_ratio,
+          params.geometry_data.radius_buffer_ratio);
 
       AssertThrow(
         initial_solution->n_order_parameters() <= MAX_SINTERING_GRAINS,


### PR DESCRIPTION
Recently I tried to run cases with zero thickness interface. They worked, but the obtained initial colorization is far suboptimal.