### PR TITLE
Override certain parameters via command line

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/parameters.h
+++ b/applications/sintering/include/pf-applications/sintering/parameters.h
@@ -6,6 +6,8 @@
 
 #include <pf-applications/sintering/preconditioners.h>
 
+#include <boost/algorithm/string.hpp>
+
 namespace Sintering
 {
   struct ApproximationData
@@ -323,6 +325,22 @@ namespace Sintering
       add_parameters(prm);
 
       prm.parse_input(file_name, "", true);
+    }
+
+    void
+    set(const std::string param, const std::string val)
+    {
+      dealii::ParameterHandler prm;
+      add_parameters(prm);
+
+      std::vector<std::string> param_path;
+      boost::split(param_path, param, boost::is_any_of("."));
+
+      for (auto it = param_path.begin(); it != param_path.end(); ++it)
+        if (std::distance(it, param_path.end()) > 1)
+          prm.enter_subsection(*it);
+        else
+          prm.set(*it, val);
     }
 
     void

--- a/applications/sintering/sintering.cc
+++ b/applications/sintering/sintering.cc
@@ -61,6 +61,28 @@ concatenate_strings(const int argc, char **argv)
   return result;
 }
 
+void
+parse_params(const int              argc,
+             char **                argv,
+             const unsigned int     offset,
+             Sintering::Parameters &params,
+             ConditionalOStream &   pcout)
+{
+  if (argc == offset + 1)
+    {
+      pcout << "Input parameters file:" << std::endl;
+      pcout << std::ifstream(argv[offset]).rdbuf() << std::endl;
+
+      params.parse(std::string(argv[offset]));
+    }
+
+  params.check();
+
+  pcout << "Parameters in JSON format:" << std::endl;
+  params.print_input();
+  pcout << std::endl;
+}
+
 int
 main(int argc, char **argv)
 {
@@ -107,19 +129,7 @@ main(int argc, char **argv)
       pcout << "Number of grains: " << n_grains << std::endl;
       pcout << std::endl;
 
-      if (argc == 5)
-        {
-          pcout << "Input parameters file:" << std::endl;
-          pcout << std::ifstream(argv[4]).rdbuf() << std::endl;
-
-          params.parse(std::string(argv[4]));
-        }
-
-      params.check();
-
-      pcout << "Parameters in JSON format:" << std::endl;
-      params.print_input();
-      pcout << std::endl;
+      parse_params(argc, argv, 4, params, pcout);
 
       const auto initial_solution =
         std::make_shared<Sintering::InitialValuesCircle<SINTERING_DIM>>(
@@ -174,19 +184,7 @@ main(int argc, char **argv)
       pcout << " = " << n_total_grains << std::endl;
       pcout << std::endl;
 
-      if (argc == 4 + SINTERING_DIM)
-        {
-          pcout << "Input parameters file:" << std::endl;
-          pcout << std::ifstream(argv[3 + SINTERING_DIM]).rdbuf() << std::endl;
-
-          params.parse(std::string(argv[3 + SINTERING_DIM]));
-        }
-
-      params.check();
-
-      pcout << "Parameters in JSON format:" << std::endl;
-      params.print_input();
-      pcout << std::endl;
+      parse_params(argc, argv, 3 + SINTERING_DIM, params, pcout);
 
       // By default, 2 order parameters are enough for the packing description
       // If minimization is not required, then 0 value disables it
@@ -230,15 +228,7 @@ main(int argc, char **argv)
       pcout << fstream.rdbuf();
       pcout << std::endl;
 
-      if (argc == 4)
-        {
-          pcout << "Input parameters file:" << std::endl;
-          pcout << std::ifstream(argv[3]).rdbuf() << std::endl;
-
-          params.parse(std::string(argv[3]));
-        }
-
-      params.check();
+      parse_params(argc, argv, 3, params, pcout);
 
       pcout << "Parameters in JSON format:" << std::endl;
       params.print_input();
@@ -270,19 +260,7 @@ main(int argc, char **argv)
       pcout << "Restart path: " << restart_path << std::endl;
       pcout << std::endl;
 
-      if (argc == 4)
-        {
-          pcout << "Input parameters file:" << std::endl;
-          pcout << std::ifstream(argv[3]).rdbuf() << std::endl;
-
-          params.parse(std::string(argv[3]));
-        }
-
-      params.check();
-
-      pcout << "Parameters in JSON format:" << std::endl;
-      params.print_input();
-      pcout << std::endl;
+      parse_params(argc, argv, 3, params, pcout);
 
       Sintering::Problem<SINTERING_DIM> runner(params, restart_path);
     }
@@ -291,19 +269,7 @@ main(int argc, char **argv)
       // Output case specific info
       pcout << "Mode: debug" << std::endl;
 
-      if (argc == 3)
-        {
-          pcout << "Input parameters file:" << std::endl;
-          pcout << std::ifstream(argv[2]).rdbuf() << std::endl;
-
-          params.parse(std::string(argv[2]));
-        }
-
-      params.check();
-
-      pcout << "Parameters in JSON format:" << std::endl;
-      params.print_input();
-      pcout << std::endl;
+      parse_params(argc, argv, 2, params, pcout);
 
       const auto initial_solution =
         std::make_shared<Sintering::InitialValuesDebug<SINTERING_DIM>>();

--- a/applications/sintering/sintering.cc
+++ b/applications/sintering/sintering.cc
@@ -92,7 +92,9 @@ parse_params(const int              argc,
           AssertThrow(std::regex_search(flag, matches, rgx),
                       ExcMessage("Incorrect parameter string specified: " +
                                  flag + "\nThe correct format is:\n" +
-                                 "--Path.To.Option=\"value\""));
+                                 "--Path.To.Option=\"value\"\nor\n" +
+                                 "--Path.To.Option=value\n" +
+                                 "if 'value' does not contain spaces"));
 
           const std::string param_name  = matches[1].str();
           const std::string param_value = matches[2].str();

--- a/applications/sintering/sintering.cc
+++ b/applications/sintering/sintering.cc
@@ -69,9 +69,7 @@ parse_params(const int              argc,
              Sintering::Parameters &params,
              ConditionalOStream &   pcout)
 {
-  const auto u_argc = static_cast<unsigned int>(argc);
-
-  if (u_argc >= offset + 1)
+  if (static_cast<unsigned int>(argc) >= offset + 1)
     {
       pcout << "Input parameters file:" << std::endl;
       pcout << std::ifstream(argv[offset]).rdbuf() << std::endl;
@@ -80,7 +78,7 @@ parse_params(const int              argc,
     }
 
   // Override params directly via command line
-  for (unsigned int i = offset + 1; i < u_argc; ++i)
+  for (unsigned int i = offset + 1; i < static_cast<unsigned int>(argc); ++i)
     {
       const std::string flag = std::string(argv[i]);
 


### PR DESCRIPTION
One can do now something like this and redefine certain options directly from the command line:
```
 ./applications/sintering/sintering-2D-generic-scalar --circle 7.5 2 settings.json --TimeIntegration.TimeStepInit=1e-1
```