### PR TITLE
More reliable filtering of new grains for the grain tracker

### DIFF
--- a/applications/sintering/analysis_examples/2d_titanium.json
+++ b/applications/sintering/analysis_examples/2d_titanium.json
@@ -35,7 +35,7 @@
         "BufferDistanceRatio": "0.05",
         "GrainTrackerFrequency": "0",
         "ThresholdLower": "0.01",
-        "ThresholdUpper": "1.01"
+        "ThresholdNewGrains": "0.02"
     },
     "Material": {
         "EnergyRealistic": {

--- a/applications/sintering/analysis_examples/2particles_pbc.json
+++ b/applications/sintering/analysis_examples/2particles_pbc.json
@@ -33,7 +33,7 @@
         "BufferDistanceRatio": "0.05",
         "GrainTrackerFrequency": "10",
         "ThresholdLower": "0.01",
-        "ThresholdUpper": "1.01"
+        "ThresholdNewGrains": "0.02"
     },
     "Material": {
         "EnergyAbstract": {

--- a/applications/sintering/analysis_examples/3d_default.json
+++ b/applications/sintering/analysis_examples/3d_default.json
@@ -37,7 +37,7 @@
         "BufferDistanceRatio": "0.05",
         "GrainTrackerFrequency": "25",
         "ThresholdLower": "0.01",
-        "ThresholdUpper": "1.01"
+        "ThresholdNewGrains": "0.02"
     },
     "Material": {
         "EnergyAbstract": {

--- a/applications/sintering/analysis_examples/49particles.json
+++ b/applications/sintering/analysis_examples/49particles.json
@@ -34,7 +34,7 @@
         "BufferDistanceRatio": "0.05",
         "GrainTrackerFrequency": "25",
         "ThresholdLower": "0.01",
-        "ThresholdUpper": "1.01"
+        "ThresholdNewGrains": "0.02"
     },
     "Material": {
         "EnergyAbstract": {

--- a/applications/sintering/analysis_examples/49particles_delta_min_05.json
+++ b/applications/sintering/analysis_examples/49particles_delta_min_05.json
@@ -34,7 +34,7 @@
         "BufferDistanceRatio": "0.05",
         "GrainTrackerFrequency": "25",
         "ThresholdLower": "0.01",
-        "ThresholdUpper": "1.01"
+        "ThresholdNewGrains": "0.02"
     },
     "Material": {
         "EnergyAbstract": {

--- a/applications/sintering/analysis_examples/49particles_delta_min_10.json
+++ b/applications/sintering/analysis_examples/49particles_delta_min_10.json
@@ -34,7 +34,7 @@
         "BufferDistanceRatio": "0.05",
         "GrainTrackerFrequency": "25",
         "ThresholdLower": "0.01",
-        "ThresholdUpper": "1.01"
+        "ThresholdNewGrains": "0.02"
     },
     "Material": {
         "EnergyAbstract": {

--- a/applications/sintering/analysis_examples/49particles_delta_min_20.json
+++ b/applications/sintering/analysis_examples/49particles_delta_min_20.json
@@ -34,7 +34,7 @@
         "BufferDistanceRatio": "0.05",
         "GrainTrackerFrequency": "25",
         "ThresholdLower": "0.01",
-        "ThresholdUpper": "1.01"
+        "ThresholdNewGrains": "0.02"
     },
     "Material": {
         "EnergyAbstract": {

--- a/applications/sintering/analysis_examples/49particles_delta_min_30.json
+++ b/applications/sintering/analysis_examples/49particles_delta_min_30.json
@@ -34,7 +34,7 @@
         "BufferDistanceRatio": "0.05",
         "GrainTrackerFrequency": "25",
         "ThresholdLower": "0.01",
-        "ThresholdUpper": "1.01"
+        "ThresholdNewGrains": "0.02"
     },
     "Material": {
         "EnergyAbstract": {

--- a/applications/sintering/analysis_examples/49particles_delta_min_40.json
+++ b/applications/sintering/analysis_examples/49particles_delta_min_40.json
@@ -35,7 +35,7 @@
         "BufferDistanceRatio": "0.05",
         "GrainTrackerFrequency": "25",
         "ThresholdLower": "0.01",
-        "ThresholdUpper": "1.01"
+        "ThresholdNewGrains": "0.02"
     },
     "Material": {
         "EnergyAbstract": {

--- a/applications/sintering/analysis_examples/49particles_delta_min_40_coarse.json
+++ b/applications/sintering/analysis_examples/49particles_delta_min_40_coarse.json
@@ -35,7 +35,7 @@
         "BufferDistanceRatio": "0.05",
         "GrainTrackerFrequency": "25",
         "ThresholdLower": "0.01",
-        "ThresholdUpper": "1.01"
+        "ThresholdNewGrains": "0.02"
     },
     "Material": {
         "EnergyAbstract": {

--- a/applications/sintering/analysis_examples/49particles_delta_min_40_ultimate.json
+++ b/applications/sintering/analysis_examples/49particles_delta_min_40_ultimate.json
@@ -35,7 +35,7 @@
         "BufferDistanceRatio": "0.05",
         "GrainTrackerFrequency": "25",
         "ThresholdLower": "0.01",
-        "ThresholdUpper": "1.01"
+        "ThresholdNewGrains": "0.02"
     },
     "Material": {
         "EnergyAbstract": {

--- a/applications/sintering/analysis_examples/49particles_delta_min_40_wang.json
+++ b/applications/sintering/analysis_examples/49particles_delta_min_40_wang.json
@@ -43,7 +43,7 @@
         "BufferDistanceRatio": "0.05",
         "GrainTrackerFrequency": "25",
         "ThresholdLower": "0.01",
-        "ThresholdUpper": "1.01"
+        "ThresholdNewGrains": "0.02"
     },
     "Material": {
         "EnergyAbstract": {

--- a/applications/sintering/analysis_examples/49particles_delta_min_50.json
+++ b/applications/sintering/analysis_examples/49particles_delta_min_50.json
@@ -35,7 +35,7 @@
         "BufferDistanceRatio": "0.05",
         "GrainTrackerFrequency": "25",
         "ThresholdLower": "0.01",
-        "ThresholdUpper": "1.01"
+        "ThresholdNewGrains": "0.02"
     },
     "Material": {
         "EnergyAbstract": {

--- a/applications/sintering/analysis_examples/49particles_delta_min_50.json
+++ b/applications/sintering/analysis_examples/49particles_delta_min_50.json
@@ -18,7 +18,7 @@
         "CustomBoundingBox": "false",
         "DivisionsPerInterface": "3",
         "HangingNodeWeight": "1",
-        "InterfaceBufferRatio": "3",
+        "InterfaceBufferRatio": "2.5",
         "InterfaceWidth": "10",
         "MinimizeOrderParameters": "true",
         "Periodic": "false",

--- a/applications/sintering/analysis_examples/49particles_delta_min_50_coarse.json
+++ b/applications/sintering/analysis_examples/49particles_delta_min_50_coarse.json
@@ -35,7 +35,7 @@
         "BufferDistanceRatio": "0.05",
         "GrainTrackerFrequency": "25",
         "ThresholdLower": "0.01",
-        "ThresholdUpper": "1.01"
+        "ThresholdNewGrains": "0.02"
     },
     "Material": {
         "EnergyAbstract": {

--- a/applications/sintering/analysis_examples/49particles_delta_min_50_coarse.json
+++ b/applications/sintering/analysis_examples/49particles_delta_min_50_coarse.json
@@ -18,7 +18,7 @@
         "CustomBoundingBox": "false",
         "DivisionsPerInterface": "2",
         "HangingNodeWeight": "1",
-        "InterfaceBufferRatio": "3",
+        "InterfaceBufferRatio": "2.5",
         "InterfaceWidth": "10",
         "MinimizeOrderParameters": "true",
         "Periodic": "false",

--- a/applications/sintering/analysis_examples/49particles_iso.json
+++ b/applications/sintering/analysis_examples/49particles_iso.json
@@ -31,7 +31,7 @@
         "BufferDistanceRatio": "0.05",
         "GrainTrackerFrequency": "25",
         "ThresholdLower": "0.01",
-        "ThresholdUpper": "1.01"
+        "ThresholdNewGrains": "0.02"
     },
     "Material": {
         "EnergyAbstract": {

--- a/applications/sintering/analysis_examples/5particles.json
+++ b/applications/sintering/analysis_examples/5particles.json
@@ -34,7 +34,7 @@
         "BufferDistanceRatio": "0.05",
         "GrainTrackerFrequency": "10",
         "ThresholdLower": "0.01",
-        "ThresholdUpper": "1.01"
+        "ThresholdNewGrains": "0.02"
     },
     "Material": {
         "EnergyAbstract": {

--- a/applications/sintering/analysis_examples/default.json
+++ b/applications/sintering/analysis_examples/default.json
@@ -49,7 +49,7 @@
         "BufferDistanceRatio": "0.05",
         "GrainTrackerFrequency": "10",
         "ThresholdLower": "0.01",
-        "ThresholdUpper": "1.01"
+        "ThresholdNewGrains": "0.02"
     },
     "Material": {
         "EnergyAbstract": {

--- a/applications/sintering/analysis_examples/termuhlen.json
+++ b/applications/sintering/analysis_examples/termuhlen.json
@@ -34,7 +34,7 @@
         "BufferDistanceRatio": "0.1",
         "GrainTrackerFrequency": "20",
         "ThresholdLower": "0.01",
-        "ThresholdUpper": "1.01"
+        "ThresholdNewGrains": "0.02"
     },
     "Material": {
         "EnergyAbstract": {

--- a/applications/sintering/include/pf-applications/sintering/driver.h
+++ b/applications/sintering/include/pf-applications/sintering/driver.h
@@ -878,7 +878,7 @@ namespace Sintering
         params.grain_tracker_data.fast_reassignment,
         MAX_SINTERING_GRAINS,
         params.grain_tracker_data.threshold_lower,
-        params.grain_tracker_data.threshold_upper,
+        params.grain_tracker_data.threshold_new_grains,
         params.grain_tracker_data.buffer_distance_ratio,
         params.grain_tracker_data.buffer_distance_fixed,
         order_parameters_offset,

--- a/applications/sintering/include/pf-applications/sintering/parameters.h
+++ b/applications/sintering/include/pf-applications/sintering/parameters.h
@@ -72,7 +72,7 @@ namespace Sintering
   struct GrainTrackerData
   {
     double       threshold_lower         = 0.01;
-    double       threshold_upper         = 1.01;
+    double       threshold_new_grains    = 0.02;
     double       buffer_distance_ratio   = 0.05;
     double       buffer_distance_fixed   = 0.0;
     unsigned int grain_tracker_frequency = 10; // 0 - no grain tracker
@@ -547,9 +547,9 @@ namespace Sintering
       prm.add_parameter("ThresholdLower",
                         grain_tracker_data.threshold_lower,
                         "Lower boundary for detecting grain.");
-      prm.add_parameter("ThresholdUpper",
-                        grain_tracker_data.threshold_upper,
-                        "Upper boundary for detecting grain.");
+      prm.add_parameter("ThresholdNewGrains",
+                        grain_tracker_data.threshold_new_grains,
+                        "Lower boundary for detecting new grain.");
       prm.add_parameter("BufferDistanceRatio",
                         grain_tracker_data.buffer_distance_ratio,
                         "Ratio of the transfer buffer (to the grain radius).");

--- a/include/pf-applications/grain_tracker/distributed_stitching.h
+++ b/include/pf-applications/grain_tracker/distributed_stitching.h
@@ -55,7 +55,7 @@ namespace GrainTracker
     cell->get_dof_values(solution, values);
 
     const auto cell_max_value = *std::max_element(values.begin(), values.end());
-    const bool has_particle   = cell_max_value > 0;
+    const bool has_particle   = cell_max_value > threshold_lower;
 
     if (!has_particle)
       return 0; // cell has no particle

--- a/include/pf-applications/grain_tracker/distributed_stitching.h
+++ b/include/pf-applications/grain_tracker/distributed_stitching.h
@@ -22,6 +22,7 @@ namespace GrainTracker
                const VectorSolution &                         solution,
                VectorIds &                                    particle_ids,
                const unsigned int                             id,
+               double &                                       max_value,
                const double threshold_lower     = 0,
                const double invalid_particle_id = -1.0)
   {
@@ -34,6 +35,7 @@ namespace GrainTracker
                                        solution,
                                        particle_ids,
                                        id,
+                                       max_value,
                                        threshold_lower,
                                        invalid_particle_id);
 
@@ -52,16 +54,15 @@ namespace GrainTracker
 
     cell->get_dof_values(solution, values);
 
-    const bool has_particle = std::any_of(values.begin(),
-                                          values.end(),
-                                          [threshold_lower](const auto &val) {
-                                            return val > threshold_lower;
-                                          }) &&
-                              values.mean_value() > 0;
+    const auto cell_max_value = *std::max_element(values.begin(), values.end());
+    const bool has_particle   = cell_max_value > 0;
+
     if (!has_particle)
       return 0; // cell has no particle
 
     particle_ids[cell->global_active_cell_index()] = id;
+
+    max_value = std::max(max_value, cell_max_value);
 
     unsigned int counter = 1;
 
@@ -71,6 +72,7 @@ namespace GrainTracker
                                      solution,
                                      particle_ids,
                                      id,
+                                     max_value,
                                      threshold_lower,
                                      invalid_particle_id);
 

--- a/include/pf-applications/grain_tracker/grain.h
+++ b/include/pf-applications/grain_tracker/grain.h
@@ -72,6 +72,13 @@ namespace GrainTracker
       return max_radius;
     }
 
+    /* Maximum value of the order parameter in the grain. */
+    double
+    get_max_value() const
+    {
+      return max_value;
+    }
+
     /* Get grain id. */
     unsigned int
     get_grain_id() const
@@ -134,14 +141,18 @@ namespace GrainTracker
       segments.push_back(segment);
 
       max_radius = std::max(max_radius, segment.get_radius());
+      max_value  = std::max(max_value, segment.get_max_value());
     }
 
     void
-    add_segment(const Point<dim> &center, const double radius)
+    add_segment(const Point<dim> &center,
+                const double      radius,
+                const double      op_value)
     {
-      segments.emplace_back(center, radius);
+      segments.emplace_back(center, radius, op_value);
 
       max_radius = std::max(max_radius, radius);
+      max_value  = std::max(max_value, op_value);
     }
 
     /* Add a grain's neighbor. Neighbors are grains having the same order
@@ -202,5 +213,7 @@ namespace GrainTracker
     double distance_to_nearest_neighbor{std::numeric_limits<double>::max()};
 
     Dynamics dynamics{None};
+
+    double max_value{std::numeric_limits<double>::min()};
   };
 } // namespace GrainTracker

--- a/include/pf-applications/grain_tracker/grain.h
+++ b/include/pf-applications/grain_tracker/grain.h
@@ -214,6 +214,6 @@ namespace GrainTracker
 
     Dynamics dynamics{None};
 
-    double max_value{std::numeric_limits<double>::min()};
+    double max_value{std::numeric_limits<double>::lowest()};
   };
 } // namespace GrainTracker

--- a/include/pf-applications/grain_tracker/segment.h
+++ b/include/pf-applications/grain_tracker/segment.h
@@ -7,15 +7,19 @@ namespace GrainTracker
   using namespace dealii;
 
   /* Segment is a part of a grain created from the previously detected cloud.
-   * Segments are represented as circles with a given center and radius.
+   * Segments are represented as circles with a given center, radius and order
+   * parameter maximum value.
    */
   template <int dim>
   class Segment
   {
   public:
-    Segment(const Point<dim> &center_in, const double radius_in)
+    Segment(const Point<dim> &center_in,
+            const double      radius_in,
+            const double      max_value_in = 0.0)
       : center(center_in)
       , radius(radius_in)
+      , max_value(max_value_in)
     {}
 
     const Point<dim> &

--- a/include/pf-applications/grain_tracker/segment.h
+++ b/include/pf-applications/grain_tracker/segment.h
@@ -31,6 +31,12 @@ namespace GrainTracker
     }
 
     double
+    get_max_value() const
+    {
+      return max_value;
+    }
+
+    double
     distance(const Segment<dim> &other) const
     {
       const double distance_centers = get_center().distance(other.get_center());
@@ -45,5 +51,7 @@ namespace GrainTracker
     Point<dim> center;
 
     double radius;
+
+    double max_value;
   };
 } // namespace GrainTracker

--- a/include/pf-applications/grain_tracker/tracker.h
+++ b/include/pf-applications/grain_tracker/tracker.h
@@ -1110,8 +1110,9 @@ namespace GrainTracker
           // local ids
           particle_ids = invalid_particle_id;
 
-          unsigned int counter = 0;
-          unsigned int offset  = 0;
+          unsigned int counter      = 0;
+          unsigned int offset       = 0;
+          double       op_max_value = std::numeric_limits<double>::min();
 
           const auto &solution_order_parameter = solution.block(
             current_order_parameter_id + order_parameters_offset);
@@ -1131,18 +1132,17 @@ namespace GrainTracker
 
             for (const auto &cell : dof_handler.active_cell_iterators())
               {
-                double max_value = std::numeric_limits<double>::min();
-
                 if (run_flooding<dim>(cell,
                                       solution_order_parameter,
                                       particle_ids,
                                       counter,
-                                      max_value,
+                                      op_max_value,
                                       threshold_lower,
                                       invalid_particle_id) > 0)
                   {
                     counter++;
-                    local_particle_max_values.push_back(max_value);
+                    local_particle_max_values.push_back(op_max_value);
+                    op_max_value = std::numeric_limits<double>::min();
                   }
               }
 

--- a/include/pf-applications/grain_tracker/tracker.h
+++ b/include/pf-applications/grain_tracker/tracker.h
@@ -52,13 +52,13 @@ namespace GrainTracker
             const bool                              allow_new_grains,
             const bool                              fast_reassignment,
             const unsigned int                      max_order_parameters_num,
-            const double                            threshold_lower = 0.01,
-            const double                            threshold_upper = 1.01,
-            const double       buffer_distance_ratio                = 0.05,
-            const double       buffer_distance_fixed                = 0.0,
-            const unsigned int order_parameters_offset              = 2,
-            const bool         do_timing                            = true,
-            const bool         use_old_remap                        = false)
+            const double                            threshold_lower      = 0.01,
+            const double                            threshold_new_grains = 0.02,
+            const double       buffer_distance_ratio                     = 0.05,
+            const double       buffer_distance_fixed                     = 0.0,
+            const unsigned int order_parameters_offset                   = 2,
+            const bool         do_timing                                 = true,
+            const bool         use_old_remap = false)
       : dof_handler(dof_handler)
       , tria(tria)
       , greedy_init(greedy_init)
@@ -66,7 +66,7 @@ namespace GrainTracker
       , fast_reassignment(fast_reassignment)
       , max_order_parameters_num(max_order_parameters_num)
       , threshold_lower(threshold_lower)
-      , threshold_upper(threshold_upper)
+      , threshold_new_grains(threshold_new_grains)
       , buffer_distance_ratio(buffer_distance_ratio)
       , buffer_distance_fixed(buffer_distance_fixed)
       , order_parameters_offset(order_parameters_offset)
@@ -88,7 +88,7 @@ namespace GrainTracker
                                                fast_reassignment,
                                                max_order_parameters_num,
                                                threshold_lower,
-                                               threshold_upper,
+                                               threshold_new_grains,
                                                buffer_distance_ratio,
                                                buffer_distance_fixed,
                                                order_parameters_offset,
@@ -191,7 +191,8 @@ namespace GrainTracker
           typename Grain<dim>::Dynamics new_dynamics = Grain<dim>::None;
 
           // Check the grain number
-          if (new_grain_id == std::numeric_limits<unsigned int>::max())
+          if (new_grain_id == std::numeric_limits<unsigned int>::max() &&
+              new_grain.get_max_value() > threshold_new_grains)
             {
               if (allow_new_grains)
                 {
@@ -2104,8 +2105,8 @@ namespace GrainTracker
     // Minimum value of order parameter value
     const double threshold_lower;
 
-    // Maximum value of order parameter value
-    const double threshold_upper;
+    // Minimum threshold for the new grains
+    const double threshold_new_grains;
 
     // Buffer zone around the grain - ratio value
     const double buffer_distance_ratio;

--- a/include/pf-applications/grain_tracker/tracker.h
+++ b/include/pf-applications/grain_tracker/tracker.h
@@ -1116,6 +1116,8 @@ namespace GrainTracker
           const auto &solution_order_parameter = solution.block(
             current_order_parameter_id + order_parameters_offset);
 
+          std::vector<double> local_particle_max_values;
+
           {
             ScopedName sc("run_flooding");
             MyScope    scope(timer, sc, timer.is_enabled());
@@ -1126,8 +1128,6 @@ namespace GrainTracker
 
             if (has_ghost_elements == false)
               solution_order_parameter.update_ghost_values();
-
-            std::vector<double> local_particle_max_values;
 
             for (const auto &cell : dof_handler.active_cell_iterators())
               {

--- a/include/pf-applications/grain_tracker/tracker.h
+++ b/include/pf-applications/grain_tracker/tracker.h
@@ -1246,7 +1246,8 @@ namespace GrainTracker
               n_particles = Utilities::MPI::max(n_particles, comm) + 1;
             }
 
-          std::vector<double> particle_info(n_particles * (1 + dim));
+          const unsigned int n_features = 1 + dim;
+          std::vector<double> particle_info(n_particles * n_features);
 
           // ... compute local information
           for (const auto &cell :
@@ -1264,10 +1265,10 @@ namespace GrainTracker
 
                 AssertIndexRange(unique_id, n_particles);
 
-                particle_info[(dim + 1) * unique_id + 0] += cell->measure();
+                particle_info[n_features * unique_id + 0] += cell->measure();
 
                 for (unsigned int d = 0; d < dim; ++d)
-                  particle_info[(dim + 1) * unique_id + 1 + d] +=
+                  particle_info[n_features * unique_id + 1 + d] +=
                     cell->center()[d] * cell->measure();
               }
 
@@ -1286,8 +1287,8 @@ namespace GrainTracker
               for (unsigned int d = 0; d < dim; ++d)
                 {
                   particle_centers[i][d] =
-                    particle_info[i * (1 + dim) + 1 + d] /
-                    particle_info[i * (1 + dim)];
+                    particle_info[i * n_features + 1 + d] /
+                    particle_info[i * n_features];
                 }
             }
 

--- a/include/pf-applications/grain_tracker/tracker.h
+++ b/include/pf-applications/grain_tracker/tracker.h
@@ -1112,7 +1112,7 @@ namespace GrainTracker
 
           unsigned int counter      = 0;
           unsigned int offset       = 0;
-          double       op_max_value = std::numeric_limits<double>::min();
+          double       op_max_value = std::numeric_limits<double>::lowest();
 
           const auto &solution_order_parameter = solution.block(
             current_order_parameter_id + order_parameters_offset);
@@ -1142,7 +1142,7 @@ namespace GrainTracker
                   {
                     counter++;
                     local_particle_max_values.push_back(op_max_value);
-                    op_max_value = std::numeric_limits<double>::min();
+                    op_max_value = std::numeric_limits<double>::lowest();
                   }
               }
 

--- a/include/pf-applications/grain_tracker/tracker.h
+++ b/include/pf-applications/grain_tracker/tracker.h
@@ -207,7 +207,7 @@ namespace GrainTracker
                     std::make_pair(numerator_invalid++, new_grain));
                 }
             }
-          else
+          else if (new_grain_id != std::numeric_limits<unsigned int>::max())
             {
               // clang-format off
               AssertThrow(old_grains.at(new_grain_id).get_order_parameter_id() 

--- a/tests/distributed_stitching_02.cc
+++ b/tests/distributed_stitching_02.cc
@@ -116,12 +116,14 @@ main(int argc, char **argv)
   unsigned int counter   = 0;
   unsigned int offset    = 0;
   const double threshold = 1e-9;
+  double       max_value = std::numeric_limits<double>::min();
 
   for (const auto &cell : dof_handler.active_cell_iterators())
     if (GrainTracker::run_flooding<dim>(cell,
                                         solution,
                                         particle_ids,
                                         counter,
+                                        max_value,
                                         threshold,
                                         invalid_particle_id) > 0)
       counter++;

--- a/tests/grain_tracker_advection_periodic.cc
+++ b/tests/grain_tracker_advection_periodic.cc
@@ -183,7 +183,7 @@ main(int argc, char **argv)
 
   // Grain tracker settings
   const double       threshold_lower          = 1e-15;
-  const double       threshold_upper          = 1.01;
+  const double       threshold_new_grains     = 1e-15;
   const double       buffer_distance_ratio    = 0.05;
   const double       buffer_distance_fixed    = 0.0;
   const bool         allow_new_grains         = false;
@@ -199,7 +199,7 @@ main(int argc, char **argv)
                                                    fast_reassignment,
                                                    max_order_parameters_num,
                                                    threshold_lower,
-                                                   threshold_upper,
+                                                   threshold_new_grains,
                                                    buffer_distance_ratio,
                                                    buffer_distance_fixed,
                                                    op_offset);

--- a/tests/grain_tracker_periodic_corner.cc
+++ b/tests/grain_tracker_periodic_corner.cc
@@ -137,7 +137,7 @@ main(int argc, char **argv)
 
   // Grain tracker settings
   const double       threshold_lower          = 1e-15;
-  const double       threshold_upper          = 1.01;
+  const double       threshold_new_grains     = 1e-15;
   const double       buffer_distance_ratio    = 0.05;
   const double       buffer_distance_fixed    = 0.0;
   const bool         allow_new_grains         = false;
@@ -153,7 +153,7 @@ main(int argc, char **argv)
                                                    fast_reassignment,
                                                    max_order_parameters_num,
                                                    threshold_lower,
-                                                   threshold_upper,
+                                                   threshold_new_grains,
                                                    buffer_distance_ratio,
                                                    buffer_distance_fixed,
                                                    op_offset);

--- a/tests/include/tangent_tester.h
+++ b/tests/include/tangent_tester.h
@@ -166,7 +166,7 @@ namespace Test
 
     // Grain tracker settings
     const double       threshold_lower          = 1e-15;
-    const double       threshold_upper          = 1.01;
+    const double       threshold_new_grains     = 1e-15;
     const double       buffer_distance_ratio    = 0.05;
     const double       buffer_distance_fixed    = 0.0;
     const bool         allow_new_grains         = false;
@@ -182,7 +182,7 @@ namespace Test
                                                      fast_reassignment,
                                                      max_order_parameters_num,
                                                      threshold_lower,
-                                                     threshold_upper,
+                                                     threshold_new_grains,
                                                      buffer_distance_ratio,
                                                      buffer_distance_fixed,
                                                      op_offset);


### PR DESCRIPTION
It seems that for coarse meshes a given order parameter can have values a bit higher than the threshold values in the vicinity of grains. Such situations for coarse meshes are not easy to control so I decided to introduce a tighter threshold for new grains. It make sense since sometimes it is not easy to distinguish a new grain appearing from numerical noise. At least the last case from [this comment](https://github.com/hpsint/hpsint/pull/520#issuecomment-1498701896) seems to work.