### PR TITLE
Update ghosts in dynamic block vector

### DIFF
--- a/include/pf-applications/lac/dynamic_block_vector.h
+++ b/include/pf-applications/lac/dynamic_block_vector.h
@@ -97,6 +97,8 @@ namespace dealii
               if (blocks[b] == nullptr)
                 blocks[b] = std::make_shared<BlockType>();
               block(b).reinit(V.block(b), omit_zeroing_entries);
+              if (block(0).has_ghost_elements())
+                block(b).update_ghost_values();
             }
 
           size_ = 0;

--- a/include/pf-applications/lac/dynamic_block_vector.h
+++ b/include/pf-applications/lac/dynamic_block_vector.h
@@ -56,7 +56,7 @@ namespace dealii
                 blocks[b] = std::make_shared<BlockType>();
               block(b).reinit(V.block(b), true);
               block(b) = V.block(b);
-              
+
               if (V.block(b).has_ghost_elements())
                 block(b).update_ghost_values();
             }

--- a/include/pf-applications/lac/dynamic_block_vector.h
+++ b/include/pf-applications/lac/dynamic_block_vector.h
@@ -81,7 +81,11 @@ namespace dealii
                 blocks[b] = std::make_shared<BlockType>();
 
               if (old_blocks_size != 0)
-                block(b).reinit(block(0), omit_zeroing_entries);
+                {
+                  block(b).reinit(block(0), omit_zeroing_entries);
+                  if (block(0).has_ghost_elements())
+                    block(b).update_ghost_values();
+                }
             }
 
           size_ = 0;

--- a/include/pf-applications/lac/dynamic_block_vector.h
+++ b/include/pf-applications/lac/dynamic_block_vector.h
@@ -56,6 +56,9 @@ namespace dealii
                 blocks[b] = std::make_shared<BlockType>();
               block(b).reinit(V.block(b), true);
               block(b) = V.block(b);
+              
+              if (V.block(b).has_ghost_elements())
+                block(b).update_ghost_values();
             }
 
           size_ = 0;


### PR DESCRIPTION
When working on #524, I also thougth that the issue might have come from DBV. I found another inconsistency there. If new blocks are added here via reinit, they turn out to be always without ghost values. This is not a desirable behavior I guess since all blocks of DBV should be of the same state regarding ghosts. And then I observed something like this by checking this situation immediately after https://github.com/hpsint/hpsint/blob/494d433774f7e3f952deb2a7537f62aab935813c/applications/sintering/include/pf-applications/sintering/driver.h#L1784-L1785

```
Running: ./applications/sintering/sintering-2D-generic-scalar ./applications/sintering/sintering-2D-generic-scalar --cloud /home/kapusta/development/hpsint/applications/sintering/sintering_cloud_examples/5particles.cloud /home/kapusta/work/pf-applications/settings/test_gt_crashes.prm
  - deal.II (branch: nox_snes; revision: 95bc7dee0c40197da08a757d881c20ef4f291bad; short: 95bc7dee0c)
  - hpsint (branch: gt_filter_new_grains; revision: d325a378bc608f72b33f32d0504d44e98b5588a2; short: d325a37)


Mode:       cloud
Cloud path: /home/kapusta/development/hpsint/applications/sintering/sintering_cloud_examples/5particles.cloud

Particles list:
#x,y,z,r
7.816,7.637,0,7.5
20.883,6.742,0,6.5
9.666,22.494,0,9.0
22.0,16.647,0,7.0
23.104,28.354,0,6.5
Input parameters file:
set MatrixBased = true
subsection Approximation
    set FEDegree = 1
    set NPoints1D = 2
    set NSubdivisions = 1
end
subsection Geometry
    set DivisionsPerInterface = 2 #3 # 4
    set BoundaryFactor = 0.5
    set InterfaceWidth = 2.0 #1.0 #2.0
    set MinimizeOrderParameters = true
    set InterfaceBufferRatio = 1.0
    set GlobalRefinement = Base #Base, set to Full if AMR is disabled
    set MaxPrime = 20
    set MaxLevel0DivisionsPerInterface = 0.99999
end
subsection Adaptivity
    set TopFractionOfCells = 0.3
    set BottomFractionOfCells = 0.1
    set MinRefinementDepth = 3
    set MaxRefinementDepth = 0 #1
    set RefinementFrequency = 1 # 10 - 0 - to disable AMR
end
subsection GrainTracker
    set ThresholdLower = 0.001
    set ThresholdUpper = 1.01
    set BufferDistanceRatio = 0.26 #0.05
    set GrainTrackerFrequency = 1 #5 # 10 - 0 - to disable GT
end
subsection Material
    set Type = Abstract

    subsection EnergyAbstract4
        set A = 2
        set B = 0.125
        set KappaC = 2.5 #1.25
        set KappaP = 0.5
    end
    subsection EnergyAbstract3
        set A = 32
        set B = 8 #1
        set KappaC = 2
        set KappaP = 1.5 #0.5
    end
    subsection EnergyAbstract2
        set A = 16
        set B = 4 #1
        set KappaC = 1
        set KappaP = 0.75 #0.5
    end
    subsection EnergyAbstract
        set A = 16
        set B = 1
        set KappaC = 1
        set KappaP = 0.5
    end
    subsection MobilityAbstract0
        set Mvol = 1e-2
        set Mvap = 1e-10
        set Msurf = 1 #4, 1
        set Mgb = 1 #0.4, 10
        set L = 1
    end
    subsection MobilityAbstract # To debug RBM with MOOSE
        set Mvol = 0.01
        set Mvap = 1e-10
        set Msurf = 4.0
        set Mgb = 0.4
        set L = 1
    end
end
subsection Advection
    set Enable = false
    set K = 20
    set Mt = 1 #10
    set Mr = 0
    set Cgb = 0.14
    set Ceq = 1
end
subsection NonLinearData
    set NonLinearSolverType = damped # NOX, damped
    set NewtonUseDamping = false
    #set NewtonReusePreconditioner = false
    set FDMJacobianApproximation = false # true - for FDM tangents

    subsection NOXData
        set OutputInformation = 0
        set DirectionMethod = Newton
        set LineSearchMethod = Full Step # Full Step, Polynomial
        set LineSearchInterpolationType = Cubic # Quadratic, Quadratic3
    end
end
subsection Restart
    set Interval = 1
    set MaximalOutput = 0
    set Prefix = ./restart
    set Type = never #never
    set FlexibleOutput = true
    set FullHistory = true
end
subsection TimeIntegration
    set TimeStart = 0
    set TimeEnd = 200 #1000 # 5e-3
    set TimeStepInit = 1e-2
    set TimeStepMin = 1e-5
    set TimeStepMax = 1e2
    set GrowthFactor = 1.2
    set DesirableNewtonIterations = 5
    set DesirableLinearIterations = 100
    set IntegrationScheme = BDF2
end
subsection Output
    set Regular = false #true
    set Contour = false #true
    set Debug = false
    set HigherOrderCells = false
    set OutputTimeInterval = 0.001
    set VtkPath = /mnt/c/Temp/verification
    #set Fields = CH,AC,bnds,dt,d2f,M,dM,kappa,L,subdomain
    set Fields = CH,AC,bnds,flux,energy
    set Shrinkage = false #true
    set FluxesDivergences = false #true
    set Table = true
    #set IsoSurfaceArea = true
    #set IsoGrainBoundariesArea = true
end
subsection Preconditioners
    set OuterPreconditioner = ILU #ILU, BlockPreconditioner2

    subsection BlockPreconditioner2
        set Block0Preconditioner = ILU
        set Block1Preconditioner = InverseDiagonalMatrix
    end

    subsection BlockPreconditioner3
        set Type = LD
        set Block0Preconditioner = ILU
        set Block0RelativeTolerance = 0.0
        set Block1Preconditioner = ILU
        set Block1RelativeToleranceexite = 0.0
        set Block2PreconditionerBlock2RelativeTolerance = InverseDiagonalMatrix
        set Block2RelativeTolerance = 0.0
    end

    subsection BlockPreconditioner3CH
        set Block0Preconditioner = AMG
        set Block2Preconditioner = InverseDiagonalMatrix
    end
end

...

Finite element: FE_Q<2>, n_subdivisions = 1
Create subdivided hyperrectangle [38.288000 x 43.717000] = [-4.184000...34.104000 x -4.363000...39.354000]
with 3 refinements (global = 1, delayed = 2) and 5x6 subdivisions

System statistics:
  - n cell:                    120 (min: 28, max: 32)
  - n cell w hanging nodes:    0 (min: 0, max: 0)
  - n cell wo hanging nodes:   120 (min: 28, max: 32)
  - n cell fine batch:         120 (min: 28, max: 32)
  - n levels:                  2
  - n coarse cells:            30
  - n theoretical fine cells:  120
  - n dofs:                    143

Mobility type: scalar

Number of local refinements to be performed: 2
Execute refinement/coarsening:
System statistics:
  - n cell:                    342 (min: 84, max: 87)
  - n cell w hanging nodes:    97 (min: 20, max: 29)
  - n cell wo hanging nodes:   245 (min: 55, max: 66)
  - n cell fine batch:         300 (min: 72, max: 80)
  - n levels:                  3
  - n coarse cells:            30
  - n theoretical fine cells:  480
  - n dofs:                    392
  - n components:              6

Execute refinement/coarsening:
System statistics:
  - n cell:                    1047 (min: 261, max: 262)
  - n cell w hanging nodes:    351 (min: 76, max: 98)
  - n cell wo hanging nodes:   696 (min: 164, max: 185)
  - n cell fine batch:         976 (min: 232, max: 252)
  - n levels:                  4
  - n coarse cells:            30
  - n theoretical fine cells:  1920
  - n dofs:                    1181
  - n components:              6

Execute grain tracker:
Collisions detected: 0 | has_reassigned_grains = false | has_op_number_changed = false
Grain tracker CPU time = 0.0846765 sec
Number of order parameters: 4
Number of grains: 5
op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 0
    segment: center = 7.6027 7.24784 | radius = 10.8482
op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 1
    segment: center = 23.3072 28.8169 | radius = 9.84017
op_index_current = 1 | op_index_old = 1 | segments = 1 | grain_index = 2
    segment: center = 20.8143 6.29647 | radius = 8.96943
op_index_current = 2 | op_index_old = 2 | segments = 1 | grain_index = 3
    segment: center = 9.386 22.9164 | radius = 12.0497
op_index_current = 3 | op_index_old = 3 | segments = 1 | grain_index = 4
    segment: center = 22.5705 16.7602 | radius = 10.1155


it      res_abs      res_rel   ch_rel_abs   ch_res_rel   ac_rel_abs   ac_res_rel  mec_rel_abs  mec_res_rel  linear_iter
 0 2.395997e+01 ------------ 1.061203e-13 ------------ 7.476325e+00 ------------ 0.000000e+00 ------------            0

Create sparsity pattern (sintering_op) with:
 - NNZ: 392724

 1 5.690625e+00 2.375055e-01 7.808004e+00 7.357690e+13 7.739545e-02 1.035207e-02 0.000000e+00 0.000000e+00            3
 2 6.176643e-02 2.577901e-03 7.213780e-02 6.797737e+11 9.045488e-04 1.209884e-04 0.000000e+00 0.000000e+00            4
 3 1.140693e-03 4.760828e-05 1.563085e-03 1.472937e+10 7.034782e-05 9.409411e-06 0.000000e+00 0.000000e+00            3
 4 1.605484e-05 6.700693e-07 2.229234e-05 2.100667e+08 1.742474e-06 2.330655e-07 0.000000e+00 0.000000e+00            4

t = 0, t_n = 0, dt = 0.01: solved in 4 Newton iterations and 14 linear iterations
Increasing timestep, dt = 0.012
Execute refinement/coarsening:
System statistics:
  - n cell:                    1032 (min: 255, max: 260)
  - n cell w hanging nodes:    378 (min: 87, max: 105)
  - n cell wo hanging nodes:   654 (min: 154, max: 168)
  - n cell fine batch:         936 (min: 228, max: 236)
  - n levels:                  4
  - n coarse cells:            30
  - n theoretical fine cells:  1920
  - n dofs:                    1177
  - n components:              6

Execute grain tracker:
Collisions detected: 0 | has_reassigned_grains = false | has_op_number_changed = false
Grain tracker CPU time = 0.0819548 sec
Number of order parameters: 4
Number of grains: 5
op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 0
    segment: center = 7.59331 7.27165 | radius = 10.8721
op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 1
    segment: center = 23.3144 28.7381 | radius = 9.84778
op_index_current = 1 | op_index_old = 1 | segments = 1 | grain_index = 2
    segment: center = 20.7256 6.23003 | radius = 9.07989
op_index_current = 2 | op_index_old = 2 | segments = 1 | grain_index = 3
    segment: center = 9.43676 22.8727 | radius = 12.1158
op_index_current = 3 | op_index_old = 3 | segments = 1 | grain_index = 4
    segment: center = 22.5961 16.7799 | radius = 10.1086


it      res_abs      res_rel   ch_rel_abs   ch_res_rel   ac_rel_abs   ac_res_rel  mec_rel_abs  mec_res_rel  linear_iter
 0 5.556742e+01 ------------ 7.696357e+01 ------------ 1.106241e+01 ------------ 0.000000e+00 ------------            0

Create sparsity pattern (sintering_op) with:
 - NNZ: 392580

 1 2.146835e+00 3.863479e-02 2.917181e+00 3.790339e-02 9.327972e-02 8.432133e-03 0.000000e+00 0.000000e+00            3
 2 5.161920e-02 9.289473e-04 7.166554e-02 9.311618e-04 4.648129e-03 4.201733e-04 0.000000e+00 0.000000e+00            3
 3 1.769958e-04 3.185244e-06 2.422830e-04 3.148021e-06 2.681255e-05 2.423753e-06 0.000000e+00 0.000000e+00            5

t = 0.01, t_n = 1, dt = 0.012: solved in 3 Newton iterations and 11 linear iterations
Increasing timestep, dt = 0.0144
Execute refinement/coarsening:
System statistics:
  - n cell:                    1029 (min: 255, max: 260)
  - n cell w hanging nodes:    380 (min: 87, max: 107)
  - n cell wo hanging nodes:   649 (min: 149, max: 168)
  - n cell fine batch:         932 (min: 224, max: 236)
  - n levels:                  4
  - n coarse cells:            30
  - n theoretical fine cells:  1920
  - n dofs:                    1175
  - n components:              6

Execute grain tracker:
Found an overlap between grain 0 and grain 1 with order parameter 0
Collisions detected: 1 | has_reassigned_grains = true | has_op_number_changed = true
Grain tracker CPU time = 0.0795858 sec
Number of order parameters: 5
Number of grains: 5
op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 0
    segment: center = 7.54543 7.50114 | radius = 11.3686
op_index_current = 1 | op_index_old = 0 | segments = 1 | grain_index = 1
    segment: center = 23.3238 28.6877 | radius = 10.2654
op_index_current = 2 | op_index_old = 1 | segments = 1 | grain_index = 2
    segment: center = 20.971 6.33956 | radius = 9.76389
op_index_current = 3 | op_index_old = 2 | segments = 1 | grain_index = 3
    segment: center = 9.86523 22.7167 | radius = 12.5783
op_index_current = 4 | op_index_old = 3 | segments = 1 | grain_index = 4
    segment: center = 22.4072 16.9161 | radius = 10.3409
Changing number of components from 6 to 7
solution[0] block[0]: has_ghost_elements = true
solution[0] block[1]: has_ghost_elements = true
solution[0] block[2]: has_ghost_elements = true
solution[0] block[3]: has_ghost_elements = true
solution[0] block[4]: has_ghost_elements = true
solution[0] block[5]: has_ghost_elements = true
solution[0] block[6]: has_ghost_elements = false
solution[1] block[0]: has_ghost_elements = true
solution[1] block[1]: has_ghost_elements = true
solution[1] block[2]: has_ghost_elements = true
solution[1] block[3]: has_ghost_elements = true
solution[1] block[4]: has_ghost_elements = true
solution[1] block[5]: has_ghost_elements = true
solution[1] block[6]: has_ghost_elements = false
Grains remapped: 4/5
```

With this PR the last check returns all true's:
```
solution[0] block[0]: has_ghost_elements = true
solution[0] block[1]: has_ghost_elements = true
solution[0] block[2]: has_ghost_elements = true
solution[0] block[3]: has_ghost_elements = true
solution[0] block[4]: has_ghost_elements = true
solution[0] block[5]: has_ghost_elements = true
solution[0] block[6]: has_ghost_elements = true
solution[1] block[0]: has_ghost_elements = true
solution[1] block[1]: has_ghost_elements = true
solution[1] block[2]: has_ghost_elements = true
solution[1] block[3]: has_ghost_elements = true
solution[1] block[4]: has_ghost_elements = true
solution[1] block[5]: has_ghost_elements = true
solution[1] block[6]: has_ghost_elements = true
Grains remapped: 4/5
```

However, this change did not fix #524 but I suppose this PR is still worth merging.

