### PR TITLE
Improve code generation for different number of grains using boost preprocessor

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/instantiation.h
+++ b/applications/sintering/include/pf-applications/sintering/instantiation.h
@@ -1,36 +1,99 @@
 #pragma once
 
+#include <boost/preprocessor.hpp>
+#include <boost/preprocessor/arithmetic/add.hpp>
+#include <boost/preprocessor/arithmetic/inc.hpp>
+#include <boost/preprocessor/repetition/repeat.hpp>
+#include <boost/preprocessor/repetition/repeat_from_to.hpp>
+
+template <typename T>
+using n_grains_t = decltype(std::declval<T const>().n_grains());
+
+template <typename T>
+using n_grains_to_n_components_t =
+  decltype(std::declval<T const>().n_grains_to_n_components(
+    std::declval<const unsigned int>()));
+
+template <typename T>
+constexpr bool has_n_grains_method =
+  dealii::internal::is_supported_operation<n_grains_t, T>
+    &&dealii::internal::is_supported_operation<n_grains_to_n_components_t, T>;
+
+DeclException3(
+  ExcInvalidNumberOfComponents,
+  unsigned int,
+  unsigned int,
+  unsigned int,
+  << "This operation is precompiled for the number of components in range ["
+  << arg1 << ", " << arg2 << "] "
+  << "but you provided n_grains = " << arg3);
+
 // clang-format off
-#define EXPAND_OPERATIONS_N_COMP_NT(OPERATION)                         \
-  constexpr int max_components = MAX_SINTERING_GRAINS + 2;             \
-  AssertThrow(n_comp_nt >= 2,                                          \
-              ExcMessage("Number of components " +                     \
-                         std::to_string(n_comp_nt) +                   \
-                         " is not precompiled!"));                     \
-  AssertThrow(n_comp_nt <= max_components +2,                          \
-              ExcMessage("Number of components " +                     \
-                         std::to_string(n_comp_nt) +                   \
-                         " is not precompiled!"));                     \
-                                                                       \
-  switch (n_comp_nt)                                                   \
-    {                                                                  \
-      case  2: { OPERATION(std::min( 2, max_components), -1); break; } \
-      case  3: { OPERATION(std::min( 3, max_components), -1); break; } \
-      case  4: { OPERATION(std::min( 4, max_components), -1); break; } \
-      case  5: { OPERATION(std::min( 5, max_components), -1); break; } \
-      case  6: { OPERATION(std::min( 6, max_components), -1); break; } \
-      case  7: { OPERATION(std::min( 7, max_components), -1); break; } \
-      case  8: { OPERATION(std::min( 8, max_components), -1); break; } \
-      case  9: { OPERATION(std::min( 9, max_components), -1); break; } \
-      case 10: { OPERATION(std::min(10, max_components), -1); break; } \
-      case 11: { OPERATION(std::min(11, max_components), -1); break; } \
-      case 12: { OPERATION(std::min(12, max_components), -1); break; } \
-      case 13: { OPERATION(std::min(13, max_components), -1); break; } \
-      case 14: { OPERATION(std::min(14, max_components), -1); break; } \
-      default:                                                         \
-        AssertThrow(false,                                             \
-                    ExcMessage("Number of components " +               \
-                               std::to_string(n_comp_nt) +             \
-                               " is not precompiled!"));               \
+/**
+ * Macro that converts a runtime number (n_components() or n_grains())
+ * to constant expressions that can be used for templating and calles
+ * the provided function with the two parameters: 1) number of
+ * components and 2) number of grains (if it makes sence; else -1).
+ *
+ * The relation between number of components and number of grains
+ * is encrypted in the method T::n_grains_to_n_components().
+ * 
+ * The function can be used the following way:
+ * ```
+ * #define OPERATION(c, d) std::cout << c << " " << d << std::endl;
+ * EXPAND_OPERATIONS(OPERATION);
+ * #undef OPERATION
+ * ```
+ */
+
+#define EXPAND_CONST(z, n, data) \
+  case n: { data(T::n_grains_to_n_components(std::min(max_grains, n)), std::min(max_grains, n)); break; }
+
+#define EXPAND_NONCONST(z, n, data) \
+  case n: { data(std::min(max_components, n), -1); break; }
+
+#define EXPAND_MAX_SINTERING_COMPONENTS \
+  BOOST_PP_ADD(MAX_SINTERING_GRAINS, 2)
+
+#define EXPAND_OPERATIONS(OPERATION)                                                                                  \
+  if constexpr(has_n_grains_method<T>)                                                                                \
+    {                                                                                                                 \
+      constexpr int max_grains = MAX_SINTERING_GRAINS;                                                                \
+      const unsigned int n_grains = static_cast<const T&>(*this).n_grains();                                          \
+      AssertIndexRange(n_grains, max_grains + 1);                                                                     \
+      switch (n_grains)                                                                                               \
+        {                                                                                                             \
+          BOOST_PP_REPEAT(BOOST_PP_INC(MAX_SINTERING_GRAINS), EXPAND_CONST, OPERATION);                               \
+          default:                                                                                                    \
+            AssertThrow(false, ExcInvalidNumberOfComponents(0, MAX_SINTERING_GRAINS, n_grains));                      \
+        }                                                                                                             \
+    }                                                                                                                 \
+  else                                                                                                                \
+    {                                                                                                                 \
+      constexpr int max_components = MAX_SINTERING_GRAINS + 2;                                                        \
+      AssertIndexRange(this->n_components(), max_components + 1);                                                     \
+      switch (this->n_components())                                                                                   \
+        {                                                                                                             \
+          BOOST_PP_REPEAT_FROM_TO(1, BOOST_PP_INC(EXPAND_MAX_SINTERING_COMPONENTS), EXPAND_NONCONST, OPERATION);      \
+          default:                                                                                                    \
+            AssertThrow(false, ExcInvalidNumberOfComponents(1, max_components, this->n_components()));                \
+        }                                                                                                             \
+  }
+
+#define EXPAND_OPERATIONS_N_COMP_NT(OPERATION)                                                               \
+  constexpr int max_components = MAX_SINTERING_GRAINS + 2;                                                   \
+  AssertThrow(n_comp_nt >= 2,                                                                                \
+              ExcMessage("Number of components " +                                                           \
+                         std::to_string(n_comp_nt) +                                                         \
+                         " is not precompiled!"));                                                           \
+  AssertThrow(n_comp_nt <= max_components +2,                                                                \
+              ExcMessage("Number of components " +                                                           \
+                         std::to_string(n_comp_nt) +                                                         \
+                         " is not precompiled!"));                                                           \
+  switch (n_comp_nt)                                                                                         \
+    {                                                                                                        \
+      BOOST_PP_REPEAT_FROM_TO(2, BOOST_PP_INC(EXPAND_MAX_SINTERING_COMPONENTS), EXPAND_NONCONST, OPERATION); \
+      default:                                                                                               \
+        AssertThrow(false, ExcInvalidNumberOfComponents(2, max_components, n_comp_nt));                      \
     }
 // clang-format on

--- a/applications/sintering/include/pf-applications/sintering/operator_base.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_base.h
@@ -10,89 +10,12 @@
 #include <pf-applications/numerics/functions.h>
 #include <pf-applications/numerics/vector_tools.h>
 
-#include <boost/preprocessor.hpp>
-#include <boost/preprocessor/repetition/repeat.hpp>
-#include <boost/preprocessor/repetition/repeat_from_to.hpp>
+#include <pf-applications/sintering/instantiation.h>
 
 #include <pf-applications/dofs/dof_tools.h>
 #include <pf-applications/matrix_free/tools.h>
 
 #include <fstream>
-
-template <typename T>
-using n_grains_t = decltype(std::declval<T const>().n_grains());
-
-template <typename T>
-using n_grains_to_n_components_t =
-  decltype(std::declval<T const>().n_grains_to_n_components(
-    std::declval<const unsigned int>()));
-
-template <typename T>
-constexpr bool has_n_grains_method =
-  dealii::internal::is_supported_operation<n_grains_t, T>
-    &&dealii::internal::is_supported_operation<n_grains_to_n_components_t, T>;
-
-DeclException3(
-  ExcInvalidNumberOfComponents,
-  unsigned int,
-  unsigned int,
-  unsigned int,
-  << "This operation is implemented for the number of components in range ["
-  << arg1 << ", " << arg2 << "] "
-  << "whereas you provided n_grains = " << arg3);
-
-// clang-format off
-/**
- * Macro that converts a runtime number (n_components() or n_grains())
- * to constant expressions that can be used for templating and calles
- * the provided function with the two parameters: 1) number of
- * components and 2) number of grains (if it makes sence; else -1).
- *
- * The relation between number of components and number of grains
- * is encrypted in the method T::n_grains_to_n_components().
- * 
- * The function can be used the following way:
- * ```
- * #define OPERATION(c, d) std::cout << c << " " << d << std::endl;
- * EXPAND_OPERATIONS(OPERATION);
- * #undef OPERATION
- * ```
- */
-
-#define EXPAND_CONST(z, n, data) \
-  case n: data(T::n_grains_to_n_components(std::min(max_grains, n)), std::min(max_grains, n)); break;
-
-#define EXPAND_NONCONST(z, n, data) \
-  case n: data(std::min(max_components, n), -1); break;
-
-#define EXPAND_MAX_SINTERING_COMPONENTS \
-  BOOST_PP_ADD(MAX_SINTERING_GRAINS, 2)
-
-#define EXPAND_OPERATIONS(OPERATION)                                                                                  \
-  if constexpr(has_n_grains_method<T>)                                                                                \
-    {                                                                                                                 \
-      constexpr int max_grains = MAX_SINTERING_GRAINS;                                                                \
-      const unsigned int n_grains = static_cast<const T&>(*this).n_grains();                                          \
-      AssertIndexRange(n_grains, max_grains + 1);                                                                     \
-      switch (n_grains)                                                                                               \
-        {                                                                                                             \
-          BOOST_PP_REPEAT(BOOST_PP_INC(MAX_SINTERING_GRAINS), EXPAND_CONST, OPERATION);                               \
-          default:                                                                                                    \
-            AssertThrow(false, ExcInvalidNumberOfComponents(0, MAX_SINTERING_GRAINS, n_grains));                      \
-        }                                                                                                             \
-    }                                                                                                                 \
-  else                                                                                                                \
-    {                                                                                                                 \
-      constexpr int max_components = MAX_SINTERING_GRAINS + 2;                                                        \
-      AssertIndexRange(this->n_components(), max_components + 1);                                                     \
-      switch (this->n_components())                                                                                   \
-        {                                                                                                             \
-          BOOST_PP_REPEAT_FROM_TO(1, BOOST_PP_INC(EXPAND_MAX_SINTERING_COMPONENTS), EXPAND_NONCONST, OPERATION);      \
-          default:                                                                                                    \
-            AssertThrow(false, ExcInvalidNumberOfComponents(1, max_components, this->n_components()));                \
-        }                                                                                                             \
-  }
-// clang-format on
 
 namespace Sintering
 {

--- a/applications/sintering/include/pf-applications/sintering/operator_base.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_base.h
@@ -10,6 +10,10 @@
 #include <pf-applications/numerics/functions.h>
 #include <pf-applications/numerics/vector_tools.h>
 
+#include <boost/preprocessor.hpp>
+#include <boost/preprocessor/repetition/repeat.hpp>
+#include <boost/preprocessor/repetition/repeat_from_to.hpp>
+
 #include <pf-applications/dofs/dof_tools.h>
 #include <pf-applications/matrix_free/tools.h>
 
@@ -28,6 +32,15 @@ constexpr bool has_n_grains_method =
   dealii::internal::is_supported_operation<n_grains_t, T>
     &&dealii::internal::is_supported_operation<n_grains_to_n_components_t, T>;
 
+DeclException3(
+  ExcInvalidNumberOfComponents,
+  unsigned int,
+  unsigned int,
+  unsigned int,
+  << "This operation is implemented for the number of components in range ["
+  << arg1 << ", " << arg2 << "] "
+  << "whereas you provided n_grains = " << arg3);
+
 // clang-format off
 /**
  * Macro that converts a runtime number (n_components() or n_grains())
@@ -45,6 +58,16 @@ constexpr bool has_n_grains_method =
  * #undef OPERATION
  * ```
  */
+
+#define EXPAND_CONST(z, n, data) \
+  case n: data(T::n_grains_to_n_components(std::min(max_grains, n)), std::min(max_grains, n)); break;
+
+#define EXPAND_NONCONST(z, n, data) \
+  case n: data(std::min(max_components, n), -1); break;
+
+#define EXPAND_MAX_SINTERING_COMPONENTS \
+  BOOST_PP_ADD(MAX_SINTERING_GRAINS, 2)
+
 #define EXPAND_OPERATIONS(OPERATION)                                                                                  \
   if constexpr(has_n_grains_method<T>)                                                                                \
     {                                                                                                                 \
@@ -53,23 +76,9 @@ constexpr bool has_n_grains_method =
       AssertIndexRange(n_grains, max_grains + 1);                                                                     \
       switch (n_grains)                                                                                               \
         {                                                                                                             \
-          case  0: OPERATION(T::n_grains_to_n_components(std::min(max_grains,  0)), std::min(max_grains,  0)); break; \
-          case  1: OPERATION(T::n_grains_to_n_components(std::min(max_grains,  1)), std::min(max_grains,  1)); break; \
-          case  2: OPERATION(T::n_grains_to_n_components(std::min(max_grains,  2)), std::min(max_grains,  2)); break; \
-          case  3: OPERATION(T::n_grains_to_n_components(std::min(max_grains,  3)), std::min(max_grains,  3)); break; \
-          case  4: OPERATION(T::n_grains_to_n_components(std::min(max_grains,  4)), std::min(max_grains,  4)); break; \
-          case  5: OPERATION(T::n_grains_to_n_components(std::min(max_grains,  5)), std::min(max_grains,  5)); break; \
-          case  6: OPERATION(T::n_grains_to_n_components(std::min(max_grains,  6)), std::min(max_grains,  6)); break; \
-          case  7: OPERATION(T::n_grains_to_n_components(std::min(max_grains,  7)), std::min(max_grains,  7)); break; \
-          case  8: OPERATION(T::n_grains_to_n_components(std::min(max_grains,  8)), std::min(max_grains,  8)); break; \
-          case  9: OPERATION(T::n_grains_to_n_components(std::min(max_grains,  9)), std::min(max_grains,  9)); break; \
-          case 10: OPERATION(T::n_grains_to_n_components(std::min(max_grains, 10)), std::min(max_grains, 10)); break; \
-          case 11: OPERATION(T::n_grains_to_n_components(std::min(max_grains, 11)), std::min(max_grains, 11)); break; \
-          case 12: OPERATION(T::n_grains_to_n_components(std::min(max_grains, 12)), std::min(max_grains, 12)); break; \
-          case 13: OPERATION(T::n_grains_to_n_components(std::min(max_grains, 13)), std::min(max_grains, 13)); break; \
-          case 14: OPERATION(T::n_grains_to_n_components(std::min(max_grains, 14)), std::min(max_grains, 14)); break; \
+          BOOST_PP_REPEAT(BOOST_PP_INC(MAX_SINTERING_GRAINS), EXPAND_CONST, OPERATION);                               \
           default:                                                                                                    \
-            AssertThrow(false, ExcNotImplemented());                                                                  \
+            AssertThrow(false, ExcInvalidNumberOfComponents(0, MAX_SINTERING_GRAINS, n_grains));                      \
         }                                                                                                             \
     }                                                                                                                 \
   else                                                                                                                \
@@ -78,22 +87,9 @@ constexpr bool has_n_grains_method =
       AssertIndexRange(this->n_components(), max_components + 1);                                                     \
       switch (this->n_components())                                                                                   \
         {                                                                                                             \
-          case  1: OPERATION(std::min(max_components,  1), -1); break;                                                \
-          case  2: OPERATION(std::min(max_components,  2), -1); break;                                                \
-          case  3: OPERATION(std::min(max_components,  3), -1); break;                                                \
-          case  4: OPERATION(std::min(max_components,  4), -1); break;                                                \
-          case  5: OPERATION(std::min(max_components,  5), -1); break;                                                \
-          case  6: OPERATION(std::min(max_components,  6), -1); break;                                                \
-          case  7: OPERATION(std::min(max_components,  7), -1); break;                                                \
-          case  8: OPERATION(std::min(max_components,  8), -1); break;                                                \
-          case  9: OPERATION(std::min(max_components,  9), -1); break;                                                \
-          case 10: OPERATION(std::min(max_components, 10), -1); break;                                                \
-          case 11: OPERATION(std::min(max_components, 11), -1); break;                                                \
-          case 12: OPERATION(std::min(max_components, 12), -1); break;                                                \
-          case 13: OPERATION(std::min(max_components, 13), -1); break;                                                \
-          case 14: OPERATION(std::min(max_components, 14), -1); break;                                                \
+          BOOST_PP_REPEAT_FROM_TO(1, BOOST_PP_INC(EXPAND_MAX_SINTERING_COMPONENTS), EXPAND_NONCONST, OPERATION);      \
           default:                                                                                                    \
-            AssertThrow(false, ExcNotImplemented());                                                                  \
+            AssertThrow(false, ExcInvalidNumberOfComponents(1, max_components, this->n_components()));                \
         }                                                                                                             \
   }
 // clang-format on

--- a/applications/sintering/include/pf-applications/sintering/operator_sintering_generic.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_sintering_generic.h
@@ -3,7 +3,6 @@
 #include <deal.II/matrix_free/tensor_product_kernels.h>
 
 #include <pf-applications/sintering/advection.h>
-#include <pf-applications/sintering/instantiation.h>
 #include <pf-applications/sintering/operator_sintering_base.h>
 
 namespace Sintering


### PR DESCRIPTION
A more flexible macro that is well in sync now with `MAX_SINTERING_GRAINS`.