### PR TITLE
Fix indices in `clear_row()` call

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/operator_sintering_coupled_base.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_sintering_coupled_base.h
@@ -78,12 +78,16 @@ namespace Sintering
     void
     post_system_matrix_compute() const override
     {
+      const auto &partitioner = this->matrix_free.get_vector_partitioner();
+
       for (const unsigned int index : zero_c_constraints_indices)
         for (unsigned int d = 0; d < dim; ++d)
           {
-            const unsigned int matrix_index = this->n_components() * index +
-                                              this->data.n_components() +
-                                              n_additional_components() + d;
+            const auto global_index = partitioner->local_to_global(index);
+
+            const unsigned int matrix_index =
+              this->n_components() * global_index + this->data.n_components() +
+              n_additional_components() + d;
 
             this->system_matrix.clear_row(matrix_index, 1.0);
           }
@@ -91,9 +95,11 @@ namespace Sintering
       for (unsigned int d = 0; d < dim; ++d)
         for (const unsigned int index : displ_constraints_indices[d])
           {
-            const unsigned int matrix_index = this->n_components() * index +
-                                              this->data.n_components() +
-                                              n_additional_components() + d;
+            const auto global_index = partitioner->local_to_global(index);
+
+            const unsigned int matrix_index =
+              this->n_components() * global_index + this->data.n_components() +
+              n_additional_components() + d;
 
             this->system_matrix.clear_row(matrix_index, 1.0);
           }

--- a/applications/sintering/include/pf-applications/sintering/preconditioners.h
+++ b/applications/sintering/include/pf-applications/sintering/preconditioners.h
@@ -250,10 +250,14 @@ namespace Sintering
     void
     post_system_matrix_compute() const override
     {
+      const auto &partitioner = this->matrix_free.get_vector_partitioner();
+
       for (unsigned int d = 0; d < dim; ++d)
         for (const unsigned int index : displ_constraints_indices[d])
           {
-            const unsigned int matrix_index = dim * index + d;
+            const auto global_index = partitioner->local_to_global(index);
+
+            const unsigned int matrix_index = dim * global_index + d;
 
             this->system_matrix.clear_row(matrix_index, 1.0);
           }

--- a/applications/structural/include/pf-applications/structural/operator_elastic_linear.h
+++ b/applications/structural/include/pf-applications/structural/operator_elastic_linear.h
@@ -180,12 +180,16 @@ namespace Structural
     void
     post_system_matrix_compute() const override
     {
+      const auto &partitioner = this->matrix_free.get_vector_partitioner();
+
       for (unsigned int d = 0; d < dim; ++d)
         for (unsigned int i = 0; i < dirichlet_constraints_indices[d].size();
              ++i)
           {
-            const unsigned int matrix_index =
-              dim * dirichlet_constraints_indices[d][i] + d;
+            const auto global_index =
+              partitioner->local_to_global(dirichlet_constraints_indices[d][i]);
+
+            const unsigned int matrix_index = dim * global_index + d;
 
             this->system_matrix.clear_row(matrix_index, 1.0);
           }


### PR DESCRIPTION
Our indices are local, but `clear_row()` operates. As the result, the mechanical boundary conditions in MPI case were imposed wrongly for ranks >= 2, like this:
![image](https://github.com/hpsint/hpsint/assets/8836201/1b2c2d37-f264-4ee6-8c76-8b830faa0dae)
whereas it should be like this:
![image](https://github.com/hpsint/hpsint/assets/8836201/56d855b6-9f56-4faf-a33a-3247ab80e2ce)
