### PR TITLE
Add dealii namespace

### DIFF
--- a/benchmarks/operators.h
+++ b/benchmarks/operators.h
@@ -177,10 +177,12 @@ public:
           const VectorizedArrayType grad = Number(n_sub) / (val0 - val1);
 
           const auto src_vectors =
-            internal::get_vector_data<n_components>(src, 0, false, 0, &dof_info)
+            dealii::internal::get_vector_data<n_components>(
+              src, 0, false, 0, &dof_info)
               .first;
           const auto dst_vectors =
-            internal::get_vector_data<n_components>(dst, 0, false, 0, &dof_info)
+            dealii::internal::get_vector_data<n_components>(
+              dst, 0, false, 0, &dof_info)
               .first;
 
           for (unsigned int cell = range.first; cell < range.second; ++cell)


### PR DESCRIPTION
Intel compiler fails to compile the likwid benchmark complaining about the `internal` namescpase ambiguity.