### PR TITLE
Fix bug in obtaining max values per segment inside GrainTracker

### DIFF
--- a/include/pf-applications/grain_tracker/distributed_stitching.h
+++ b/include/pf-applications/grain_tracker/distributed_stitching.h
@@ -453,8 +453,9 @@ namespace GrainTracker
           if (particle_id == invalid_particle_id)
             continue;
 
-          const unsigned int unique_id = local_to_global_particle_ids
-            [static_cast<unsigned int>(particle_id) - local_offset];
+          const unsigned int local_id =
+            static_cast<unsigned int>(particle_id) - local_offset;
+          const unsigned int unique_id = local_to_global_particle_ids[local_id];
 
           AssertIndexRange(unique_id, n_particles);
 
@@ -466,7 +467,7 @@ namespace GrainTracker
 
           if (!local_particle_max_values.empty())
             particle_max_values[unique_id] =
-              local_particle_max_values[particle_id];
+              local_particle_max_values[local_id];
         }
 
     // Reduce information - particles info
@@ -510,8 +511,9 @@ namespace GrainTracker
           if (particle_id == invalid_particle_id)
             continue;
 
-          const unsigned int unique_id = local_to_global_particle_ids
-            [static_cast<unsigned int>(particle_id) - local_offset];
+          const unsigned int local_id =
+            static_cast<unsigned int>(particle_id) - local_offset;
+          const unsigned int unique_id = local_to_global_particle_ids[local_id];
 
           AssertIndexRange(unique_id, n_particles);
 

--- a/include/pf-applications/grain_tracker/tracker.h
+++ b/include/pf-applications/grain_tracker/tracker.h
@@ -1809,7 +1809,8 @@ namespace GrainTracker
       for (const auto &segment : grain.get_segments())
         {
           out << "    segment: center = " << segment.get_center()
-              << " | radius = " << segment.get_radius() << std::endl;
+              << " | radius = " << segment.get_radius()
+              << " | max_value = " << segment.get_max_value() << std::endl;
         }
     }
 
@@ -1919,7 +1920,8 @@ namespace GrainTracker
                 current_grains.at(grain_id).get_segments()[segment_id];
 
               out << "    segment: center = " << segment.get_center()
-                  << " | radius = " << segment.get_radius() << std::endl;
+                  << " | radius = " << segment.get_radius()
+                  << " | max_value = " << segment.get_max_value() << std::endl;
             }
         }
     }


### PR DESCRIPTION
Local indices had to be deoffsetted buy `local_offset` when accessing entries in `local_particle_max_values`.