### PR TITLE
Add max value to the output

### DIFF
--- a/tests/grain_tracker_advection_periodic.mpirun=4.output
+++ b/tests/grain_tracker_advection_periodic.mpirun=4.output
@@ -5,208 +5,208 @@ Time t = 0
 Number of order parameters: 2
 Number of grains: 4
 op_index_current = 0 | op_index_old = 0 | segments = 2
-    segment: center = 3.69235 11.25 | radius = 9.4844
-    segment: center = 56.3077 11.25 | radius = 9.4844
+    segment: center = 3.69235 11.25 | radius = 9.4844 | max_value = 1
+    segment: center = 56.3077 11.25 | radius = 9.4844 | max_value = 1
 op_index_current = 1 | op_index_old = 1 | segments = 1
-    segment: center = 15 11.25 | radius = 8.89283
+    segment: center = 15 11.25 | radius = 8.89283 | max_value = 1
 op_index_current = 0 | op_index_old = 0 | segments = 1
-    segment: center = 30 11.25 | radius = 8.89283
+    segment: center = 30 11.25 | radius = 8.89283 | max_value = 1
 op_index_current = 1 | op_index_old = 1 | segments = 1
-    segment: center = 45 11.25 | radius = 8.89283
+    segment: center = 45 11.25 | radius = 8.89283 | max_value = 1
 
 Time t = 1
 Number of order parameters: 2
 Number of grains: 4
 op_index_current = 0 | op_index_old = 0 | segments = 2
-    segment: center = 4.13892 11.25 | radius = 9.66409
-    segment: center = 56.785 11.25 | radius = 9.31262
+    segment: center = 4.13892 11.25 | radius = 9.66409 | max_value = 1
+    segment: center = 56.785 11.25 | radius = 9.31262 | max_value = 1
 op_index_current = 1 | op_index_old = 1 | segments = 1
-    segment: center = 16.0096 11.25 | radius = 8.88956
+    segment: center = 16.0096 11.25 | radius = 8.88956 | max_value = 1
 op_index_current = 0 | op_index_old = 0 | segments = 1
-    segment: center = 31.0096 11.25 | radius = 8.88956
+    segment: center = 31.0096 11.25 | radius = 8.88956 | max_value = 1
 op_index_current = 1 | op_index_old = 1 | segments = 1
-    segment: center = 46.0096 11.25 | radius = 8.88956
+    segment: center = 46.0096 11.25 | radius = 8.88956 | max_value = 1
 
 Time t = 2
 Number of order parameters: 2
 Number of grains: 4
 op_index_current = 0 | op_index_old = 0 | segments = 2
-    segment: center = 4.63708 11.25 | radius = 9.63668
-    segment: center = 57.2125 11.25 | radius = 8.90921
+    segment: center = 4.63708 11.25 | radius = 9.63668 | max_value = 1
+    segment: center = 57.2125 11.25 | radius = 8.90921 | max_value = 1
 op_index_current = 1 | op_index_old = 1 | segments = 1
-    segment: center = 16.9999 11.25 | radius = 8.89733
+    segment: center = 16.9999 11.25 | radius = 8.89733 | max_value = 1
 op_index_current = 0 | op_index_old = 0 | segments = 1
-    segment: center = 31.9999 11.25 | radius = 8.89733
+    segment: center = 31.9999 11.25 | radius = 8.89733 | max_value = 1
 op_index_current = 1 | op_index_old = 1 | segments = 1
-    segment: center = 46.9999 11.25 | radius = 8.89733
+    segment: center = 46.9999 11.25 | radius = 8.89733 | max_value = 1
 
 Time t = 3
 Number of order parameters: 2
 Number of grains: 4
 op_index_current = 0 | op_index_old = 0 | segments = 2
-    segment: center = 5.12469 11.25 | radius = 9.63835
-    segment: center = 57.6396 11.25 | radius = 8.51779
+    segment: center = 5.12469 11.25 | radius = 9.63835 | max_value = 1
+    segment: center = 57.6396 11.25 | radius = 8.51779 | max_value = 1
 op_index_current = 1 | op_index_old = 1 | segments = 1
-    segment: center = 17.9905 11.25 | radius = 8.9006
+    segment: center = 17.9905 11.25 | radius = 8.9006 | max_value = 1
 op_index_current = 0 | op_index_old = 0 | segments = 1
-    segment: center = 32.9905 11.25 | radius = 8.9006
+    segment: center = 32.9905 11.25 | radius = 8.9006 | max_value = 1
 op_index_current = 1 | op_index_old = 1 | segments = 1
-    segment: center = 47.9905 11.25 | radius = 8.9006
+    segment: center = 47.9905 11.25 | radius = 8.9006 | max_value = 1
 
 Time t = 4
 Number of order parameters: 2
 Number of grains: 4
 op_index_current = 0 | op_index_old = 0 | segments = 2
-    segment: center = 5.63915 11.25 | radius = 9.68904
-    segment: center = 58.0754 11.25 | radius = 7.86425
+    segment: center = 5.63915 11.25 | radius = 9.68904 | max_value = 1
+    segment: center = 58.0754 11.25 | radius = 7.86425 | max_value = 1
 op_index_current = 1 | op_index_old = 1 | segments = 1
-    segment: center = 18.9836 11.25 | radius = 8.9027
+    segment: center = 18.9836 11.25 | radius = 8.9027 | max_value = 1
 op_index_current = 0 | op_index_old = 0 | segments = 1
-    segment: center = 33.9836 11.25 | radius = 8.9027
+    segment: center = 33.9836 11.25 | radius = 8.9027 | max_value = 1
 op_index_current = 1 | op_index_old = 1 | segments = 1
-    segment: center = 48.9836 11.25 | radius = 8.9027
+    segment: center = 48.9836 11.25 | radius = 8.9027 | max_value = 1
 
 Time t = 5
 Number of order parameters: 2
 Number of grains: 4
 op_index_current = 0 | op_index_old = 0 | segments = 2
-    segment: center = 6.18647 11.25 | radius = 9.57931
-    segment: center = 58.4913 11.25 | radius = 7.22586
+    segment: center = 6.18647 11.25 | radius = 9.57931 | max_value = 1
+    segment: center = 58.4913 11.25 | radius = 7.22586 | max_value = 1
 op_index_current = 1 | op_index_old = 1 | segments = 1
-    segment: center = 19.9937 11.25 | radius = 8.90534
+    segment: center = 19.9937 11.25 | radius = 8.90534 | max_value = 1
 op_index_current = 0 | op_index_old = 0 | segments = 1
-    segment: center = 34.9937 11.25 | radius = 8.90534
+    segment: center = 34.9937 11.25 | radius = 8.90534 | max_value = 1
 op_index_current = 1 | op_index_old = 1 | segments = 1
-    segment: center = 49.9937 11.25 | radius = 8.90534
+    segment: center = 49.9937 11.25 | radius = 8.90534 | max_value = 1
 
 Time t = 6
 Number of order parameters: 2
 Number of grains: 4
 op_index_current = 0 | op_index_old = 0 | segments = 2
-    segment: center = 6.76615 11.25 | radius = 9.36783
-    segment: center = 58.9163 11.25 | radius = 6.32086
+    segment: center = 6.76615 11.25 | radius = 9.36783 | max_value = 1
+    segment: center = 58.9163 11.25 | radius = 6.32086 | max_value = 1
 op_index_current = 1 | op_index_old = 1 | segments = 1
-    segment: center = 20.993 11.25 | radius = 8.90683
+    segment: center = 20.993 11.25 | radius = 8.90683 | max_value = 1
 op_index_current = 0 | op_index_old = 0 | segments = 1
-    segment: center = 35.993 11.25 | radius = 8.90683
+    segment: center = 35.993 11.25 | radius = 8.90683 | max_value = 1
 op_index_current = 1 | op_index_old = 1 | segments = 1
-    segment: center = 50.993 11.25 | radius = 8.90683
+    segment: center = 50.993 11.25 | radius = 8.90683 | max_value = 1
 
 Time t = 7
 Number of order parameters: 2
 Number of grains: 4
 op_index_current = 1 | op_index_old = 1 | segments = 2
-    segment: center = 0.25641 11.25 | radius = 3.15669
-    segment: center = 51.8974 11.25 | radius = 8.94104
+    segment: center = 0.25641 11.25 | radius = 3.15669 | max_value = 0.146447
+    segment: center = 51.8974 11.25 | radius = 8.94104 | max_value = 1
 op_index_current = 0 | op_index_old = 0 | segments = 2
-    segment: center = 7.40509 11.25 | radius = 9.13411
-    segment: center = 59.3184 11.25 | radius = 5.15257
+    segment: center = 7.40509 11.25 | radius = 9.13411 | max_value = 1
+    segment: center = 59.3184 11.25 | radius = 5.15257 | max_value = 0.853553
 op_index_current = 1 | op_index_old = 1 | segments = 1
-    segment: center = 22.0005 11.25 | radius = 8.87737
+    segment: center = 22.0005 11.25 | radius = 8.87737 | max_value = 1
 op_index_current = 0 | op_index_old = 0 | segments = 1
-    segment: center = 37.0005 11.25 | radius = 8.87737
+    segment: center = 37.0005 11.25 | radius = 8.87737 | max_value = 1
 
 Time t = 8
 Number of order parameters: 2
 Number of grains: 4
 op_index_current = 1 | op_index_old = 1 | segments = 2
-    segment: center = 0.681639 11.25 | radius = 5.15257
-    segment: center = 52.5949 11.25 | radius = 9.13411
+    segment: center = 0.681639 11.25 | radius = 5.15257 | max_value = 0.853553
+    segment: center = 52.5949 11.25 | radius = 9.13411 | max_value = 1
 op_index_current = 0 | op_index_old = 0 | segments = 2
-    segment: center = 8.10265 11.25 | radius = 8.94104
-    segment: center = 59.7436 11.25 | radius = 3.15669
+    segment: center = 8.10265 11.25 | radius = 8.94104 | max_value = 1
+    segment: center = 59.7436 11.25 | radius = 3.15669 | max_value = 0.146447
 op_index_current = 1 | op_index_old = 1 | segments = 1
-    segment: center = 22.9995 11.25 | radius = 8.87737
+    segment: center = 22.9995 11.25 | radius = 8.87737 | max_value = 1
 op_index_current = 0 | op_index_old = 0 | segments = 1
-    segment: center = 37.9995 11.25 | radius = 8.87737
+    segment: center = 37.9995 11.25 | radius = 8.87737 | max_value = 1
 
 Time t = 9
 Number of order parameters: 2
 Number of grains: 4
 op_index_current = 1 | op_index_old = 1 | segments = 2
-    segment: center = 1.08373 11.25 | radius = 6.32086
-    segment: center = 53.2338 11.25 | radius = 9.36783
+    segment: center = 1.08373 11.25 | radius = 6.32086 | max_value = 1
+    segment: center = 53.2338 11.25 | radius = 9.36783 | max_value = 1
 op_index_current = 0 | op_index_old = 0 | segments = 1
-    segment: center = 9.00702 11.25 | radius = 8.90683
+    segment: center = 9.00702 11.25 | radius = 8.90683 | max_value = 1
 op_index_current = 1 | op_index_old = 1 | segments = 1
-    segment: center = 24.007 11.25 | radius = 8.90683
+    segment: center = 24.007 11.25 | radius = 8.90683 | max_value = 1
 op_index_current = 0 | op_index_old = 0 | segments = 1
-    segment: center = 39.007 11.25 | radius = 8.90683
+    segment: center = 39.007 11.25 | radius = 8.90683 | max_value = 1
 
 Time t = 10
 Number of order parameters: 2
 Number of grains: 4
 op_index_current = 1 | op_index_old = 1 | segments = 2
-    segment: center = 1.50868 11.25 | radius = 7.22586
-    segment: center = 53.8135 11.25 | radius = 9.57931
+    segment: center = 1.50868 11.25 | radius = 7.22586 | max_value = 1
+    segment: center = 53.8135 11.25 | radius = 9.57931 | max_value = 1
 op_index_current = 0 | op_index_old = 0 | segments = 1
-    segment: center = 10.0063 11.25 | radius = 8.90534
+    segment: center = 10.0063 11.25 | radius = 8.90534 | max_value = 1
 op_index_current = 1 | op_index_old = 1 | segments = 1
-    segment: center = 25.0063 11.25 | radius = 8.90534
+    segment: center = 25.0063 11.25 | radius = 8.90534 | max_value = 1
 op_index_current = 0 | op_index_old = 0 | segments = 1
-    segment: center = 40.0063 11.25 | radius = 8.90534
+    segment: center = 40.0063 11.25 | radius = 8.90534 | max_value = 1
 
 Time t = 11
 Number of order parameters: 2
 Number of grains: 4
 op_index_current = 1 | op_index_old = 1 | segments = 2
-    segment: center = 1.92458 11.25 | radius = 7.86425
-    segment: center = 54.3609 11.25 | radius = 9.68904
+    segment: center = 1.92458 11.25 | radius = 7.86425 | max_value = 1
+    segment: center = 54.3609 11.25 | radius = 9.68904 | max_value = 1
 op_index_current = 0 | op_index_old = 0 | segments = 1
-    segment: center = 11.0164 11.25 | radius = 8.9027
+    segment: center = 11.0164 11.25 | radius = 8.9027 | max_value = 1
 op_index_current = 1 | op_index_old = 1 | segments = 1
-    segment: center = 26.0164 11.25 | radius = 8.9027
+    segment: center = 26.0164 11.25 | radius = 8.9027 | max_value = 1
 op_index_current = 0 | op_index_old = 0 | segments = 1
-    segment: center = 41.0164 11.25 | radius = 8.9027
+    segment: center = 41.0164 11.25 | radius = 8.9027 | max_value = 1
 
 Time t = 12
 Number of order parameters: 2
 Number of grains: 4
 op_index_current = 1 | op_index_old = 1 | segments = 2
-    segment: center = 2.36039 11.25 | radius = 8.51779
-    segment: center = 54.8753 11.25 | radius = 9.63835
+    segment: center = 2.36039 11.25 | radius = 8.51779 | max_value = 1
+    segment: center = 54.8753 11.25 | radius = 9.63835 | max_value = 1
 op_index_current = 0 | op_index_old = 0 | segments = 1
-    segment: center = 12.0095 11.25 | radius = 8.9006
+    segment: center = 12.0095 11.25 | radius = 8.9006 | max_value = 1
 op_index_current = 1 | op_index_old = 1 | segments = 1
-    segment: center = 27.0095 11.25 | radius = 8.9006
+    segment: center = 27.0095 11.25 | radius = 8.9006 | max_value = 1
 op_index_current = 0 | op_index_old = 0 | segments = 1
-    segment: center = 42.0095 11.25 | radius = 8.9006
+    segment: center = 42.0095 11.25 | radius = 8.9006 | max_value = 1
 
 Time t = 13
 Number of order parameters: 2
 Number of grains: 4
 op_index_current = 1 | op_index_old = 1 | segments = 2
-    segment: center = 2.78754 11.25 | radius = 8.90921
-    segment: center = 55.3629 11.25 | radius = 9.63668
+    segment: center = 2.78754 11.25 | radius = 8.90921 | max_value = 1
+    segment: center = 55.3629 11.25 | radius = 9.63668 | max_value = 1
 op_index_current = 0 | op_index_old = 0 | segments = 1
-    segment: center = 13.0001 11.25 | radius = 8.89733
+    segment: center = 13.0001 11.25 | radius = 8.89733 | max_value = 1
 op_index_current = 1 | op_index_old = 1 | segments = 1
-    segment: center = 28.0001 11.25 | radius = 8.89733
+    segment: center = 28.0001 11.25 | radius = 8.89733 | max_value = 1
 op_index_current = 0 | op_index_old = 0 | segments = 1
-    segment: center = 43.0001 11.25 | radius = 8.89733
+    segment: center = 43.0001 11.25 | radius = 8.89733 | max_value = 1
 
 Time t = 14
 Number of order parameters: 2
 Number of grains: 4
 op_index_current = 1 | op_index_old = 1 | segments = 2
-    segment: center = 3.21495 11.25 | radius = 9.31262
-    segment: center = 55.8611 11.25 | radius = 9.66409
+    segment: center = 3.21495 11.25 | radius = 9.31262 | max_value = 1
+    segment: center = 55.8611 11.25 | radius = 9.66409 | max_value = 1
 op_index_current = 0 | op_index_old = 0 | segments = 1
-    segment: center = 13.9904 11.25 | radius = 8.88956
+    segment: center = 13.9904 11.25 | radius = 8.88956 | max_value = 1
 op_index_current = 1 | op_index_old = 1 | segments = 1
-    segment: center = 28.9904 11.25 | radius = 8.88956
+    segment: center = 28.9904 11.25 | radius = 8.88956 | max_value = 1
 op_index_current = 0 | op_index_old = 0 | segments = 1
-    segment: center = 43.9904 11.25 | radius = 8.88956
+    segment: center = 43.9904 11.25 | radius = 8.88956 | max_value = 1
 
 Time t = 15
 Number of order parameters: 2
 Number of grains: 4
 op_index_current = 1 | op_index_old = 1 | segments = 2
-    segment: center = 3.69235 11.25 | radius = 9.4844
-    segment: center = 56.3077 11.25 | radius = 9.4844
+    segment: center = 3.69235 11.25 | radius = 9.4844 | max_value = 1
+    segment: center = 56.3077 11.25 | radius = 9.4844 | max_value = 1
 op_index_current = 0 | op_index_old = 0 | segments = 1
-    segment: center = 15 11.25 | radius = 8.89283
+    segment: center = 15 11.25 | radius = 8.89283 | max_value = 1
 op_index_current = 1 | op_index_old = 1 | segments = 1
-    segment: center = 30 11.25 | radius = 8.89283
+    segment: center = 30 11.25 | radius = 8.89283 | max_value = 1
 op_index_current = 0 | op_index_old = 0 | segments = 1
-    segment: center = 45 11.25 | radius = 8.89283
+    segment: center = 45 11.25 | radius = 8.89283 | max_value = 1

--- a/tests/grain_tracker_periodic_corner.mpirun=4.output
+++ b/tests/grain_tracker_periodic_corner.mpirun=4.output
@@ -4,9 +4,9 @@ with 3 refinements (global = 3, delayed = 0) and 10x10 subdivisions
 Number of order parameters: 1
 Number of grains: 2
 op_index_current = 0 | op_index_old = 0 | segments = 4
-    segment: center = 0.879673 0.879673 | radius = 1.42509
-    segment: center = 0.879673 9.12033 | radius = 1.42509
-    segment: center = 9.12033 0.879673 | radius = 1.42509
-    segment: center = 9.12033 9.12033 | radius = 1.42509
+    segment: center = 0.879673 0.879673 | radius = 1.42509 | max_value = 1
+    segment: center = 0.879673 9.12033 | radius = 1.42509 | max_value = 1
+    segment: center = 9.12033 0.879673 | radius = 1.42509 | max_value = 1
+    segment: center = 9.12033 9.12033 | radius = 1.42509 | max_value = 1
 op_index_current = 0 | op_index_old = 0 | segments = 1
-    segment: center = 5 5 | radius = 2.15184
+    segment: center = 5 5 | radius = 2.15184 | max_value = 1


### PR DESCRIPTION
Some grain tracker tests got broken after #553. This PR fixes them.