### PR TITLE
Mark invalid grains in the grain tracker

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/operator_advection.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_advection.h
@@ -258,6 +258,8 @@ namespace Sintering
 
               for (; i < segments.size(); ++i)
                 {
+                  bool set_invalid = false;
+
                   const auto icell = matrix_free.get_cell_iterator(cell, i);
                   const auto cell_index = icell->global_active_cell_index();
 
@@ -269,19 +271,33 @@ namespace Sintering
                       const auto grain_and_segment =
                         grain_tracker.get_grain_and_segment(ig, particle_id);
 
-                      const auto &rc_i = grain_tracker.get_segment_center(
-                        grain_and_segment.first, grain_and_segment.second);
+                      if (grain_and_segment.first !=
+                          numbers::invalid_unsigned_int)
+                        {
+                          const auto &rc_i = grain_tracker.get_segment_center(
+                            grain_and_segment.first, grain_and_segment.second);
 
-                      for (unsigned int d = 0; d < dim; ++d)
-                        rc[d][i] = rc_i[d];
+                          for (unsigned int d = 0; d < dim; ++d)
+                            rc[d][i] = rc_i[d];
 
-                      segments[i] = grain_and_segment;
+                          segments[i] = grain_and_segment;
 
-                      index_values.push_back(
-                        grain_tracker.get_grain_segment_index(
-                          grain_and_segment.first, grain_and_segment.second));
+                          index_values.push_back(
+                            grain_tracker.get_grain_segment_index(
+                              grain_and_segment.first,
+                              grain_and_segment.second));
+                        }
+                      else
+                        {
+                          set_invalid = true;
+                        }
                     }
                   else
+                    {
+                      set_invalid = true;
+                    }
+
+                  if (set_invalid)
                     {
                       segments[i] =
                         std::make_pair(numbers::invalid_unsigned_int,

--- a/include/pf-applications/grain_tracker/tracker.h
+++ b/include/pf-applications/grain_tracker/tracker.h
@@ -259,26 +259,25 @@ namespace GrainTracker
               grains.emplace(std::make_pair(new_grain_id, new_grain));
               grains.at(new_grain_id).set_grain_id(new_grain_id);
               grains.at(new_grain_id).set_dynamics(new_dynamics);
+            }
 
-              // Update mapping if we changed the grain id
-              if (new_grain_id != current_grain_id)
+          // Update mapping if we changed the grain id
+          if (new_grain_id != current_grain_id)
+            {
+              auto &particle_to_grain =
+                particle_ids_to_grain_ids[new_grain.get_order_parameter_id()];
+
+              for (unsigned int ip = 0; ip < particle_to_grain.size(); ip++)
                 {
-                  auto &particle_to_grain =
-                    particle_ids_to_grain_ids[new_grain
-                                                .get_order_parameter_id()];
+                  auto &pmap = particle_to_grain[ip];
 
-                  for (unsigned int ip = 0; ip < particle_to_grain.size(); ip++)
+                  if (grains_ids_changed[new_grain.get_order_parameter_id()]
+                                        [ip] == false &&
+                      pmap.first == current_grain_id)
                     {
-                      auto &pmap = particle_to_grain[ip];
-
-                      if (grains_ids_changed[new_grain.get_order_parameter_id()]
-                                            [ip] == false &&
-                          pmap.first == current_grain_id)
-                        {
-                          pmap.first = new_grain_id;
-                          grains_ids_changed[new_grain.get_order_parameter_id()]
-                                            [ip] = true;
-                        }
+                      pmap.first = new_grain_id;
+                      grains_ids_changed[new_grain.get_order_parameter_id()]
+                                        [ip] = true;
                     }
                 }
             }

--- a/include/pf-applications/grain_tracker/tracker.h
+++ b/include/pf-applications/grain_tracker/tracker.h
@@ -1060,6 +1060,10 @@ namespace GrainTracker
     get_segment_center(const unsigned int grain_id,
                        const unsigned int segment_id) const
     {
+      Assert(grains.find(grain_id) != grains.cend(),
+             ExcMessage("Grain with grain_id = " + std::to_string(grain_id) +
+                        " does not exist in the grains map"));
+
       return grains.at(grain_id).get_segments()[segment_id].get_center();
     }
 
@@ -1067,7 +1071,20 @@ namespace GrainTracker
     get_grain_segment_index(const unsigned int grain_id,
                             const unsigned int segment_id) const
     {
-      return grain_segment_ids_numbering.at(grain_id).at(segment_id);
+      Assert(grain_segment_ids_numbering.find(grain_id) !=
+               grain_segment_ids_numbering.cend(),
+             ExcMessage("Grain with grain_id = " + std::to_string(grain_id) +
+                        " does not exist in the inverse mapping"));
+
+      const auto &grain = grain_segment_ids_numbering.at(grain_id);
+
+      Assert(grain.find(segment_id) != grain.cend(),
+             ExcMessage(
+               "Segment with segment_id = " + std::to_string(segment_id) +
+               " does not exist in the grain with grain_id = " +
+               std::to_string(grain_id)));
+
+      return grain.at(segment_id);
     }
 
     unsigned int

--- a/include/pf-applications/grain_tracker/tracker.h
+++ b/include/pf-applications/grain_tracker/tracker.h
@@ -1375,6 +1375,13 @@ namespace GrainTracker
             }
         }
 
+      AssertThrow(
+        grains_numerator == static_cast<unsigned int>(new_grains.size()),
+        ExcMessage(
+          "Inconsistent grains numbering: grains_numerator = " +
+          std::to_string(grains_numerator) +
+          " and new_grains.size() = " + std::to_string(new_grains.size())));
+
       return new_grains;
     }
 


### PR DESCRIPTION
The nearly desappearing grains had to be properly marked as invalid in the `particle_ids_to_grain_ids` mapping. A tricky bug that used to trigger crash very rarely.