### PR TITLE
Improve the rtree based grain tracking algo

### DIFF
--- a/include/pf-applications/grain_tracker/tracking.h
+++ b/include/pf-applications/grain_tracker/tracking.h
@@ -92,16 +92,55 @@ namespace GrainTracker
 
               std::vector<typename ContainerType::size_type> result;
 
-              tree.query(bgi::intersects(box) &&
-                           bgi::nearest(old_segment.get_center(), 1),
-                         std::back_inserter(result));
+              tree.query(bgi::intersects(box), std::back_inserter(result));
 
               // If any of the grain was identified, then there is no need to
               // check for the others, so we break the iteration
               if (!result.empty())
                 {
-                  new_grains_to_old.at(new_segments_to_grains[result[0]]) =
-                    grain_id;
+                  /* Perform manual sorting among the candidates, since
+                   * bgi::nearest() outputs the closest to the face of the box,
+                   * not the box having the closest center. */
+
+                  unsigned int new_grain_id = 0;
+
+                  if (result.size() > 0)
+                    {
+                      double min_dist = std::numeric_limits<double>::max();
+
+                      for (const auto &id : result)
+                        {
+                          const unsigned int candidate_grain_id =
+                            new_segments_to_grains[id];
+
+                          // Compute the segment id
+                          unsigned int work_id = id;
+                          for (; work_id > 0 &&
+                                 new_segments_to_grains[work_id - 1] ==
+                                   new_segments_to_grains[work_id];
+                               --work_id)
+                            ;
+                          const unsigned int segment_id = id - work_id;
+
+                          const auto &candidate_segment =
+                            new_grains.at(candidate_grain_id)
+                              .get_segments()[segment_id];
+
+                          const auto curent_dist =
+                            candidate_segment.get_center().distance(
+                              old_segment.get_center());
+
+                          if (curent_dist < min_dist)
+                            {
+                              new_grain_id = candidate_grain_id;
+                              min_dist     = curent_dist;
+                            }
+                        }
+                    }
+                  else
+                    new_grain_id = result[0];
+
+                  new_grains_to_old.at(new_grain_id) = grain_id;
                   break;
                 }
             }

--- a/include/pf-applications/grain_tracker/tracking.h
+++ b/include/pf-applications/grain_tracker/tracking.h
@@ -48,8 +48,6 @@ namespace GrainTracker
     // This algorithm works now only for grains with a single segment
     namespace bgi = boost::geometry::index;
 
-    using PP = std::pair<Point<dim>, Point<dim>>;
-
     using ContainerType = std::vector<BoundingBox<dim>>;
 
     const auto old_grains_per_op =

--- a/include/pf-applications/grain_tracker/tracking.h
+++ b/include/pf-applications/grain_tracker/tracking.h
@@ -92,54 +92,16 @@ namespace GrainTracker
 
               std::vector<typename ContainerType::size_type> result;
 
-              tree.query(bgi::intersects(box), std::back_inserter(result));
+              tree.query(bgi::intersects(box) &&
+                           bgi::nearest(new_segment.get_center(), 1),
+                         std::back_inserter(result));
 
               // If any of the grain was identified, then there is no need to
               // check for the others, so we break the iteration
               if (!result.empty())
                 {
-                  /* Perform manual sorting among the candidates, since
-                   * bgi::nearest() outputs the closest to the face of the box,
-                   * not the box having the closest center. */
-
-                  unsigned int old_grain_id = 0;
-
-                  if (result.size() > 1)
-                    {
-                      double min_dist = std::numeric_limits<double>::max();
-
-                      for (const auto &id : result)
-                        {
-                          const unsigned int candidate_grain_id =
-                            old_segments_to_grains[id];
-
-                          // Compute the segment id
-                          unsigned int work_id = id;
-                          for (; work_id > 0 &&
-                                 old_segments_to_grains[work_id - 1] ==
-                                   old_segments_to_grains[work_id];
-                               --work_id)
-                            ;
-                          const unsigned int segment_id = id - work_id;
-
-                          const auto &candidate_segment =
-                            old_grains.at(candidate_grain_id)
-                              .get_segments()[segment_id];
-
-                          const auto curent_dist =
-                            candidate_segment.get_center().distance(
-                              new_segment.get_center());
-
-                          if (curent_dist < min_dist)
-                            {
-                              old_grain_id = candidate_grain_id;
-                              min_dist     = curent_dist;
-                            }
-                        }
-                    }
-                  else
-                    old_grain_id = old_segments_to_grains[result[0]];
-
+                  const unsigned int old_grain_id =
+                    old_segments_to_grains[result[0]];
                   old_grains_to_new.at(old_grain_id) = grain_id;
                   break;
                 }

--- a/include/pf-applications/grain_tracker/tracking.h
+++ b/include/pf-applications/grain_tracker/tracking.h
@@ -58,7 +58,7 @@ namespace GrainTracker
       extract_grain_indices_per_op(new_grains, n_order_params);
 
     // This can be refactored such that vector is used
-    std::map<unsigned int, unsigned int> old_grains_to_new;
+    std::map<unsigned int, unsigned int> new_grains_to_old;
 
     for (unsigned int op = 0; op < n_order_params; ++op)
       {
@@ -66,12 +66,13 @@ namespace GrainTracker
 
         std::vector<unsigned int> old_segments_to_grains;
 
+        for (const unsigned int grain_id : new_grains_per_op[op])
+          new_grains_to_old.try_emplace(
+            grain_id, std::numeric_limits<unsigned int>::max());
+
         for (const unsigned int grain_id : old_grains_per_op[op])
           for (const auto &old_segment : old_grains.at(grain_id).get_segments())
             {
-              old_grains_to_new.try_emplace(
-                grain_id, std::numeric_limits<unsigned int>::max());
-
               // Flatten all segments of all grains for the given order
               // parameter
               old_segments_to_grains.push_back(grain_id);
@@ -102,17 +103,11 @@ namespace GrainTracker
                 {
                   const unsigned int old_grain_id =
                     old_segments_to_grains[result[0]];
-                  old_grains_to_new.at(old_grain_id) = grain_id;
+                  new_grains_to_old.at(grain_id) = old_grain_id;
                   break;
                 }
             }
       }
-
-    // Revert map
-    std::map<unsigned int, unsigned int> new_grains_to_old;
-    for (const auto &[old_grain_id, new_grain_id] : old_grains_to_new)
-      if (new_grain_id != std::numeric_limits<unsigned int>::max())
-        new_grains_to_old.try_emplace(new_grain_id, old_grain_id);
 
     return new_grains_to_old;
   }

--- a/tests/transfer_grain_ids_07.cc
+++ b/tests/transfer_grain_ids_07.cc
@@ -1,0 +1,129 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2023 by the hpsint authors
+//
+// This file is part of the hpsint library.
+//
+// The hpsint library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.MD at
+// the top level directory of hpsint.
+//
+// ---------------------------------------------------------------------
+
+#include <deal.II/base/mpi.h>
+
+#include <pf-applications/grain_tracker/tracking.h>
+
+using namespace dealii;
+using namespace GrainTracker;
+
+int
+main()
+{
+  // Map 2 old grains to 2 new grains: multisegments
+
+  constexpr unsigned int dim = 3;
+
+  std::map<unsigned int, Grain<dim>> old_grains;
+
+  const auto add_grain = [](std::map<unsigned int, Grain<dim>> &grains,
+                            const unsigned int                  grain_id,
+                            const double                        x,
+                            const double                        y,
+                            const double                        z,
+                            const double                        r) {
+    grains.try_emplace(grain_id, grain_id, 0);
+    grains.at(grain_id).add_segment(Point<dim>(x, y, z),
+                                    r,
+                                    4. / 3. * std::pow(r, 3) * M_PI,
+                                    1.0);
+  };
+
+  add_grain(old_grains, 0, 94.6154, 29.1288, 29.5799, 45.9676);
+  add_grain(old_grains, 1, 220.696, 45.5308, 34.6221, 55.8711);
+  add_grain(old_grains, 4, 33.2217, 247.147, 31.5111, 76.1837);
+  add_grain(old_grains, 7, 64.537, 59.9542, 217.464, 118.745);
+  add_grain(old_grains, 12, 235.693, 180.914, 188.382, 64.1163);
+  add_grain(old_grains, 15, 69.2122, 275.918, 193.333, 51.0762);
+  add_grain(old_grains, 19, 204.213, 262.26, 289.578, 41.3436);
+  add_grain(old_grains, 38, 252.499, 278.669, 30.8942, 44.5147);
+  add_grain(old_grains, 64, 17.671, 75.6835, 17.7423, 34.5737);
+  add_grain(old_grains, 69, 152.59, 179.064, 28.2257, 37.6444);
+  add_grain(old_grains, 74, 275.344, 27.2085, 262.943, 46.8655);
+
+  /*
+  op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 0
+      segment: center = 94.6154 29.1288 29.5799 | radius = 45.9676 | max_value = 0.99966
+  op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 1
+      segment: center = 220.696 45.5308 34.6221 | radius = 55.8711 | max_value = 1.00013
+  op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 4
+      segment: center = 33.2217 247.147 31.5111 | radius = 76.1837 | max_value = 1.00012
+  op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 7
+      segment: center = 64.537 59.9542 217.464 | radius = 118.745 | max_value = 1.0003
+  op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 12
+      segment: center = 235.693 180.914 188.382 | radius = 64.1163 | max_value = 0.999973
+  op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 15
+      segment: center = 69.2122 275.918 193.333 | radius = 51.0762 | max_value = 1.0001
+  op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 19
+      segment: center = 204.213 262.26 289.578 | radius = 41.3436 | max_value = 0.999883
+  op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 38
+      segment: center = 252.499 278.669 30.8942 | radius = 44.5147 | max_value = 1.00002
+  op_index_current = 0 | op_index_old = 2 | segments = 1 | grain_index = 64
+      segment: center = 17.671 75.6835 17.7423 | radius = 34.5737 | max_value = 0.969351
+  op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 69
+      segment: center = 152.59 179.064 28.2257 | radius = 37.6444 | max_value = 0.999528
+  op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 74
+      segment: center = 275.344 27.2085 262.943 | radius = 46.8655 | max_value = 0.999831
+  */
+
+  std::map<unsigned int, Grain<dim>> new_grains;
+
+  add_grain(new_grains, 701, 220.84, 45.518, 34.6399, 56.0837);
+  add_grain(new_grains, 704, 33.1791, 247.382, 31.4546, 75.9383);
+  add_grain(new_grains, 707, 64.6469, 59.9564, 217.528, 118.845);
+  add_grain(new_grains, 712, 235.507, 181.562, 188.514, 62.313);
+  add_grain(new_grains, 715, 68.6011, 275.475, 194.369, 55.9826);
+  add_grain(new_grains, 719, 204.239, 262.288, 289.49, 41.4039);
+  add_grain(new_grains, 738, 252.517, 278.719, 30.8824, 44.5405);
+  add_grain(new_grains, 764, 94.2105, 26.5377, 27.7914, 43.5742); // -> this should be grain_id=0
+  add_grain(new_grains, 769, 152.433, 179.354, 28.2189, 37.3907);
+  add_grain(new_grains, 774, 275.57, 26.7379, 263.176, 46.587);
+
+  /*
+  op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 1
+      segment: center = 220.84 45.518 34.6399 | radius = 56.0837 | max_value = 1.00014
+  op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 4
+      segment: center = 33.1791 247.382 31.4546 | radius = 75.9383 | max_value = 1.00013
+  op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 7
+      segment: center = 64.6469 59.9564 217.528 | radius = 118.845 | max_value = 1.00026
+  op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 12
+      segment: center = 235.507 181.562 188.514 | radius = 62.313 | max_value = 0.99996
+  op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 15
+      segment: center = 68.6011 275.475 194.369 | radius = 55.9826 | max_value = 1.0001
+  op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 19
+      segment: center = 204.239 262.288 289.49 | radius = 41.4039 | max_value = 0.999883
+  op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 38
+      segment: center = 252.517 278.719 30.8824 | radius = 44.5405 | max_value = 0.999993
+  op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 64
+      segment: center = 94.2105 26.5377 27.7914 | radius = 43.5742 | max_value = 0.999038
+  op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 69
+      segment: center = 152.433 179.354 28.2189 | radius = 37.3907 | max_value = 0.999463
+  op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 74
+      segment: center = 275.57 26.7379 263.176 | radius = 46.587 | max_value = 0.999785
+  */
+
+  const unsigned int n_order_params = 1;
+
+  const auto new_grains_to_old =
+    transfer_grain_ids(new_grains, old_grains, n_order_params);
+
+  std::cout << "# of old grains = " << old_grains.size() << std::endl;
+  std::cout << "# of new grains = " << new_grains.size() << std::endl;
+
+  std::cout << "Grains mapping (new_id -> old_id):" << std::endl;
+  for (const auto &[new_id, old_id] : new_grains_to_old)
+    std::cout << new_id << " -> " << old_id << std::endl;
+}

--- a/tests/transfer_grain_ids_07.cc
+++ b/tests/transfer_grain_ids_07.cc
@@ -27,8 +27,6 @@ main()
 
   constexpr unsigned int dim = 3;
 
-  std::map<unsigned int, Grain<dim>> old_grains;
-
   const auto add_grain = [](std::map<unsigned int, Grain<dim>> &grains,
                             const unsigned int                  grain_id,
                             const double                        x,
@@ -42,19 +40,7 @@ main()
                                     1.0);
   };
 
-  add_grain(old_grains, 0, 94.6154, 29.1288, 29.5799, 45.9676);
-  add_grain(old_grains, 1, 220.696, 45.5308, 34.6221, 55.8711);
-  add_grain(old_grains, 4, 33.2217, 247.147, 31.5111, 76.1837);
-  add_grain(old_grains, 7, 64.537, 59.9542, 217.464, 118.745);
-  add_grain(old_grains, 12, 235.693, 180.914, 188.382, 64.1163);
-  add_grain(old_grains, 15, 69.2122, 275.918, 193.333, 51.0762);
-  add_grain(old_grains, 19, 204.213, 262.26, 289.578, 41.3436);
-  add_grain(old_grains, 38, 252.499, 278.669, 30.8942, 44.5147);
-  add_grain(old_grains, 64, 17.671, 75.6835, 17.7423, 34.5737);
-  add_grain(old_grains, 69, 152.59, 179.064, 28.2257, 37.6444);
-  add_grain(old_grains, 74, 275.344, 27.2085, 262.943, 46.8655);
-
-  /*
+  /* Old grains
   op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 0
       segment: center = 94.6154 29.1288 29.5799 | radius = 45.9676 | max_value = 0.99966
   op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 1
@@ -79,20 +65,21 @@ main()
       segment: center = 275.344 27.2085 262.943 | radius = 46.8655 | max_value = 0.999831
   */
 
-  std::map<unsigned int, Grain<dim>> new_grains;
+  std::map<unsigned int, Grain<dim>> old_grains;
 
-  add_grain(new_grains, 701, 220.84, 45.518, 34.6399, 56.0837);
-  add_grain(new_grains, 704, 33.1791, 247.382, 31.4546, 75.9383);
-  add_grain(new_grains, 707, 64.6469, 59.9564, 217.528, 118.845);
-  add_grain(new_grains, 712, 235.507, 181.562, 188.514, 62.313);
-  add_grain(new_grains, 715, 68.6011, 275.475, 194.369, 55.9826);
-  add_grain(new_grains, 719, 204.239, 262.288, 289.49, 41.4039);
-  add_grain(new_grains, 738, 252.517, 278.719, 30.8824, 44.5405);
-  add_grain(new_grains, 764, 94.2105, 26.5377, 27.7914, 43.5742); // -> this should be grain_id=0
-  add_grain(new_grains, 769, 152.433, 179.354, 28.2189, 37.3907);
-  add_grain(new_grains, 774, 275.57, 26.7379, 263.176, 46.587);
+  add_grain(old_grains, 0, 94.6154, 29.1288, 29.5799, 45.9676);
+  add_grain(old_grains, 1, 220.696, 45.5308, 34.6221, 55.8711);
+  add_grain(old_grains, 4, 33.2217, 247.147, 31.5111, 76.1837);
+  add_grain(old_grains, 7, 64.537, 59.9542, 217.464, 118.745);
+  add_grain(old_grains, 12, 235.693, 180.914, 188.382, 64.1163);
+  add_grain(old_grains, 15, 69.2122, 275.918, 193.333, 51.0762);
+  add_grain(old_grains, 19, 204.213, 262.26, 289.578, 41.3436);
+  add_grain(old_grains, 38, 252.499, 278.669, 30.8942, 44.5147);
+  add_grain(old_grains, 64, 17.671, 75.6835, 17.7423, 34.5737);
+  add_grain(old_grains, 69, 152.59, 179.064, 28.2257, 37.6444);
+  add_grain(old_grains, 74, 275.344, 27.2085, 262.943, 46.8655);
 
-  /*
+  /* New grains
   op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 1
       segment: center = 220.84 45.518 34.6399 | radius = 56.0837 | max_value = 1.00014
   op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 4
@@ -114,6 +101,22 @@ main()
   op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 74
       segment: center = 275.57 26.7379 263.176 | radius = 46.587 | max_value = 0.999785
   */
+
+  std::map<unsigned int, Grain<dim>> new_grains;
+
+  add_grain(new_grains, 701, 220.84, 45.518, 34.6399, 56.0837);
+  add_grain(new_grains, 704, 33.1791, 247.382, 31.4546, 75.9383);
+  add_grain(new_grains, 707, 64.6469, 59.9564, 217.528, 118.845);
+  add_grain(new_grains, 712, 235.507, 181.562, 188.514, 62.313);
+  add_grain(new_grains, 715, 68.6011, 275.475, 194.369, 55.9826);
+  add_grain(new_grains, 719, 204.239, 262.288, 289.49, 41.4039);
+  add_grain(new_grains, 738, 252.517, 278.719, 30.8824, 44.5405);
+
+  // This grain should be assigned to grain_id=0
+  add_grain(new_grains, 764, 94.2105, 26.5377, 27.7914, 43.5742);
+
+  add_grain(new_grains, 769, 152.433, 179.354, 28.2189, 37.3907);
+  add_grain(new_grains, 774, 275.57, 26.7379, 263.176, 46.587);
 
   const unsigned int n_order_params = 1;
 

--- a/tests/transfer_grain_ids_07.output
+++ b/tests/transfer_grain_ids_07.output
@@ -1,5 +1,13 @@
-# of old grains = 2
-# of new grains = 2
+# of old grains = 11
+# of new grains = 10
 Grains mapping (new_id -> old_id):
-0 -> 4
-1 -> 2
+701 -> 1
+704 -> 4
+707 -> 7
+712 -> 12
+715 -> 15
+719 -> 19
+738 -> 38
+764 -> 0
+769 -> 69
+774 -> 74

--- a/tests/transfer_grain_ids_07.output
+++ b/tests/transfer_grain_ids_07.output
@@ -1,0 +1,5 @@
+# of old grains = 2
+# of new grains = 2
+Grains mapping (new_id -> old_id):
+0 -> 4
+1 -> 2

--- a/tests/transfer_grain_ids_08.cc
+++ b/tests/transfer_grain_ids_08.cc
@@ -1,0 +1,63 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2023 by the hpsint authors
+//
+// This file is part of the hpsint library.
+//
+// The hpsint library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.MD at
+// the top level directory of hpsint.
+//
+// ---------------------------------------------------------------------
+
+#include <deal.II/base/mpi.h>
+
+#include <pf-applications/grain_tracker/tracking.h>
+
+using namespace dealii;
+using namespace GrainTracker;
+
+int
+main()
+{
+  // Map 2 old grains to 2 new grains: multisegments
+
+  constexpr unsigned int dim = 2;
+
+  std::map<unsigned int, Grain<dim>> old_grains;
+
+  old_grains.try_emplace(0, 0, 0);
+  old_grains.at(0).add_segment(Point<dim>(0, 0),
+                               2.0,
+                               std::pow(2.0, 2) * M_PI,
+                               1.0);
+
+  old_grains.try_emplace(1, 1, 0);
+  old_grains.at(1).add_segment(Point<dim>(3-0.5, 0),
+                               1.0,
+                               std::pow(1.0, 2) * M_PI,
+                               1.0);
+
+  std::map<unsigned int, Grain<dim>> new_grains;
+
+  new_grains.try_emplace(0, 0, 0);
+  new_grains.at(0).add_segment(Point<dim>(0.5, 0.5),
+                               2.0,
+                               std::pow(2.0, 2) * M_PI,
+                               1.0);
+
+  const unsigned int n_order_params = 1;
+
+  const auto new_grains_to_old =
+    transfer_grain_ids(new_grains, old_grains, n_order_params);
+
+  std::cout << "# of old grains = " << old_grains.size() << std::endl;
+  std::cout << "# of new grains = " << new_grains.size() << std::endl;
+
+  std::cout << "Grains mapping (new_id -> old_id):" << std::endl;
+  for (const auto &[new_id, old_id] : new_grains_to_old)
+    std::cout << new_id << " -> " << old_id << std::endl;
+}

--- a/tests/transfer_grain_ids_08.cc
+++ b/tests/transfer_grain_ids_08.cc
@@ -36,7 +36,7 @@ main()
                                1.0);
 
   old_grains.try_emplace(1, 1, 0);
-  old_grains.at(1).add_segment(Point<dim>(3-0.5, 0),
+  old_grains.at(1).add_segment(Point<dim>(3 - 0.5, 0),
                                1.0,
                                std::pow(1.0, 2) * M_PI,
                                1.0);

--- a/tests/transfer_grain_ids_08.output
+++ b/tests/transfer_grain_ids_08.output
@@ -1,5 +1,4 @@
 # of old grains = 2
-# of new grains = 2
+# of new grains = 1
 Grains mapping (new_id -> old_id):
-0 -> 4
-1 -> 2
+0 -> 0

--- a/tests/transfer_grain_ids_08.output
+++ b/tests/transfer_grain_ids_08.output
@@ -1,0 +1,5 @@
+# of old grains = 2
+# of new grains = 2
+Grains mapping (new_id -> old_id):
+0 -> 4
+1 -> 2

--- a/tests/transfer_grain_ids_09.cc
+++ b/tests/transfer_grain_ids_09.cc
@@ -1,0 +1,111 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2023 by the hpsint authors
+//
+// This file is part of the hpsint library.
+//
+// The hpsint library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.MD at
+// the top level directory of hpsint.
+//
+// ---------------------------------------------------------------------
+
+#include <deal.II/base/mpi.h>
+
+#include <pf-applications/grain_tracker/tracking.h>
+
+using namespace dealii;
+using namespace GrainTracker;
+
+int
+main()
+{
+  // Map 2 old grains to 2 new grains: multisegments
+
+  constexpr unsigned int dim = 3;
+
+  const auto add_grain = [](std::map<unsigned int, Grain<dim>> &grains,
+                            const unsigned int                  grain_id,
+                            const double                        x,
+                            const double                        y,
+                            const double                        z,
+                            const double                        r) {
+    grains.try_emplace(grain_id, grain_id, 3);
+    grains.at(grain_id).add_segment(Point<dim>(x, y, z),
+                                    r,
+                                    4. / 3. * std::pow(r, 3) * M_PI,
+                                    1.0);
+  };
+
+  /* Old grains
+  op_index_current = 3 | op_index_old = 3 | segments = 1 | grain_index = 44
+      segment: center = 53.2446 111.374 62.851 | radius = 105.014 | max_value = 1.00019
+  op_index_current = 3 | op_index_old = 2 | segments = 1 | grain_index = 54
+      segment: center = 158.329 35.8013 165.073 | radius = 48.4995 | max_value = 1.00005
+  op_index_current = 3 | op_index_old = 3 | segments = 1 | grain_index = 59
+      segment: center = 78.3938 268.394 57.3512 | radius = 42.231 | max_value = 1.00001
+  op_index_current = 3 | op_index_old = 6 | segments = 1 | grain_index = 60
+      segment: center = 206.594 255.865 102.191 | radius = 69.555 | max_value = 1.00012
+  op_index_current = 3 | op_index_old = 3 | segments = 1 | grain_index = 61
+      segment: center = 227.119 282.278 247.636 | radius = 46.1484 | max_value = 1.00004
+  op_index_current = 3 | op_index_old = 3 | segments = 1 | grain_index = 78
+      segment: center = 91.7484 129.185 276.194 | radius = 52.248 | max_value = 1.00009
+  op_index_current = 3 | op_index_old = 5 | segments = 1 | grain_index = 92
+      segment: center = 274.079 82.588 84.6985 | radius = 49.2785 | max_value = 1.0001
+  */
+
+  std::map<unsigned int, Grain<dim>> old_grains;
+
+  add_grain(old_grains, 44, 53.2446, 111.374, 62.851, 105.014);
+  add_grain(old_grains, 54, 158.329, 35.8013, 165.073, 48.4995);
+  add_grain(old_grains, 59, 78.3938, 268.394, 57.3512, 42.231);
+  add_grain(old_grains, 60, 206.594, 255.865, 102.191, 69.555);
+  add_grain(old_grains, 61, 227.119, 282.278, 247.636, 46.1484);
+  add_grain(old_grains, 78, 91.7484, 129.185, 276.194, 52.248);
+  add_grain(old_grains, 92, 274.079, 82.588, 84.6985, 49.2785);
+
+  /* New grains
+  op_index_current = 3 | op_index_old = 3 | segments = 1 | grain_index = 4294967295
+      segment: center = 158.376 35.3881 165.533 | radius = 47.3832 | max_value = 0.999985
+  op_index_current = 3 | op_index_old = 3 | segments = 1 | grain_index = 54
+      segment: center = 53.4247 111.307 62.984 | radius = 104.959 | max_value = 1.00018
+  op_index_current = 3 | op_index_old = 3 | segments = 1 | grain_index = 59
+      segment: center = 78.4738 268.572 57.3432 | radius = 42.2616 | max_value = 1.00001
+  op_index_current = 3 | op_index_old = 3 | segments = 1 | grain_index = 60
+      segment: center = 206.329 255.794 102.117 | radius = 69.3212 | max_value = 1.00013
+  op_index_current = 3 | op_index_old = 3 | segments = 1 | grain_index = 61
+      segment: center = 227.098 282.343 247.664 | radius = 46.1728 | max_value = 1.00008
+  op_index_current = 3 | op_index_old = 3 | segments = 1 | grain_index = 78
+      segment: center = 92.3623 128.483 275.971 | radius = 53.7383 | max_value = 1.00009
+  op_index_current = 3 | op_index_old = 3 | segments = 1 | grain_index = 92
+      segment: center = 274.28 82.5818 84.719 | radius = 49.3169 | max_value = 1.00008
+  */
+
+  std::map<unsigned int, Grain<dim>> new_grains;
+
+  // This grain is unmapped in the original version, should be 54
+  add_grain(new_grains, 744, 158.376, 35.3881, 165.533, 47.3832);
+
+  // And this grain should be assigned to 44
+  add_grain(new_grains, 754, 53.4247, 111.307, 62.984, 104.959);
+  add_grain(new_grains, 759, 78.4738, 268.572, 57.3432, 42.2616);
+  add_grain(new_grains, 760, 206.329, 255.794, 102.117, 69.3212);
+  add_grain(new_grains, 761, 227.098, 282.343, 247.664, 46.1728);
+  add_grain(new_grains, 778, 92.3623, 128.483, 275.971, 53.7383);
+  add_grain(new_grains, 792, 274.28, 82.5818, 84.719, 49.3169);
+
+  const unsigned int n_order_params = 4;
+
+  const auto new_grains_to_old =
+    transfer_grain_ids(new_grains, old_grains, n_order_params);
+
+  std::cout << "# of old grains = " << old_grains.size() << std::endl;
+  std::cout << "# of new grains = " << new_grains.size() << std::endl;
+
+  std::cout << "Grains mapping (new_id -> old_id):" << std::endl;
+  for (const auto &[new_id, old_id] : new_grains_to_old)
+    std::cout << new_id << " -> " << old_id << std::endl;
+}

--- a/tests/transfer_grain_ids_09.output
+++ b/tests/transfer_grain_ids_09.output
@@ -1,0 +1,10 @@
+# of old grains = 7
+# of new grains = 7
+Grains mapping (new_id -> old_id):
+744 -> 54
+754 -> 44
+759 -> 59
+760 -> 60
+761 -> 61
+778 -> 78
+792 -> 92


### PR DESCRIPTION
Basically, the main modification is that a set of `rtree` boxes is created not from the new grains, but from the old ones. This makes more sense since in our application it is assumed that the old grains may disappear but not any new ones are allowed to appear. 

Previously, I have observed the following error. Assume at $t=t_0$ we have 2 old grains: $G_1^0$ and $G_2^0$. At the next step $G_2$ disappears, $G_1$ remains and moves slightly such that its bounding box overlaps both the boxes of $G_1^0$ and $G_2^0$. The previous algo would at first map $G_1^0 \rightarrow G_1$ (which is something we need) and then happily override it with $G_2^0 \rightarrow G_1$. This is due to the fact that the set of new grains is smaller and `rtree` is simply not aware of a better candidate at each particular moment.

This case is reproduced in test `transfer_grain_ids_08`.