### PR TITLE
Skip reassignment for the second `track()` in the case of advection

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/driver.h
+++ b/applications/sintering/include/pf-applications/sintering/driver.h
@@ -1886,7 +1886,7 @@ namespace Sintering
                 ScopedName sc("track_fast");
                 MyScope    scope(timer, sc);
 
-                const bool skip_reassignment = false;
+                const bool skip_reassignment = true;
                 grain_tracker.track(solution,
                                     sintering_data.n_grains(),
                                     skip_reassignment);


### PR DESCRIPTION
There was a bug here