### PR TITLE
Advection with conservation

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/operator_sintering_generic.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_sintering_generic.h
@@ -181,9 +181,8 @@ namespace Sintering
               const auto &velocity_ig =
                 this->advection.get_velocity(ig, phi.quadrature_point(q));
 
-              value_result[0] += velocity_ig * gradient[0];
-
-              value_result[ig + 2] += velocity_ig * gradient[ig + 2];
+              gradient_result[0] -= velocity_ig * value[0];
+              gradient_result[2 + ig] -= velocity_ig * value[2 + ig];
             }
 
 
@@ -674,8 +673,8 @@ namespace Sintering
                   const auto &velocity_ig =
                     this->advection.get_velocity(ig, phi.quadrature_point(q));
 
-                  value_result[0] += velocity_ig * gradient[0];
-                  value_result[2 + ig] += velocity_ig * gradient[2 + ig];
+                  gradient_result[0] -= velocity_ig * value[0];
+                  gradient_result[2 + ig] -= velocity_ig * value[2 + ig];
                 }
 
 

--- a/applications/sintering/include/pf-applications/sintering/preconditioners.h
+++ b/applications/sintering/include/pf-applications/sintering/preconditioners.h
@@ -149,7 +149,7 @@ namespace Sintering
               for (unsigned int d = 0; d < dim; ++d)
                 lin_v_adv[d] = val[n_grains + 2 + d] * inv_dt;
 
-              value_result[0] += lin_v_adv * phi.get_gradient(q)[0];
+              gradient_result[0] -= lin_v_adv * phi.get_value(q)[0];
             }
           else if (this->advection.enabled())
             {
@@ -162,7 +162,7 @@ namespace Sintering
                       this->advection.get_velocity(grain_to_relevant_grain[ig],
                                                    phi.quadrature_point(q));
 
-                    value_result[0] += velocity_ig * phi.get_gradient(q)[0];
+                    gradient_result[0] -= velocity_ig * phi.get_value(q)[0];
                   }
             }
 
@@ -394,7 +394,7 @@ namespace Sintering
                     lin_v_adv[d] = val[n_grains + 2 + d] * inv_dt;
 
                   for (unsigned int ig = 0; ig < n_grains; ++ig)
-                    value_result[ig] += lin_v_adv * phi.get_gradient(q)[ig];
+                    gradient_result[ig] -= lin_v_adv * phi.get_value(q)[ig];
                 }
               else if (this->advection.enabled())
                 {
@@ -407,8 +407,8 @@ namespace Sintering
                         const auto &velocity_ig = this->advection.get_velocity(
                           grain_to_relevant_grain[ig], phi.quadrature_point(q));
 
-                        value_result[ig] +=
-                          velocity_ig * phi.get_gradient(q)[ig];
+                        gradient_result[ig] -=
+                          velocity_ig * phi.get_value(q)[ig];
                       }
                 }
 
@@ -557,7 +557,7 @@ namespace Sintering
                     lin_v_adv[d] = val[n_grains + 2 + d] * inv_dt;
 
                   for (unsigned int ig = 0; ig < n_grains; ++ig)
-                    value_result[ig] += lin_v_adv * phi.get_gradient(q)[ig];
+                    gradient_result[ig] -= lin_v_adv * phi.get_value(q)[ig];
                 }
               else if (this->advection.enabled())
                 {
@@ -570,8 +570,8 @@ namespace Sintering
                         const auto &velocity_ig = this->advection.get_velocity(
                           grain_to_relevant_grain[ig], phi.quadrature_point(q));
 
-                        value_result[ig] +=
-                          velocity_ig * phi.get_gradient(q)[ig];
+                        gradient_result[ig] -=
+                          velocity_ig * phi.get_value(q)[ig];
                       }
                 }
 
@@ -825,7 +825,7 @@ namespace Sintering
                                   lin_v_adv[d] =
                                     val[this->n_grains() + 2 + d] * inv_dt;
 
-                                value_result += lin_v_adv * gradient;
+                                gradient_result -= lin_v_adv * value;
                               }
                             else if (grain_to_relevant_grain[b] !=
                                        static_cast<unsigned char>(255) &&
@@ -837,7 +837,7 @@ namespace Sintering
                                     grain_to_relevant_grain[b],
                                     integrator.quadrature_point(q));
 
-                                value_result += velocity_ig * gradient;
+                                gradient_result -= velocity_ig * value;
                               }
                           }
 

--- a/tests/residual_generic_scalar_rbm.mpirun=1.output
+++ b/tests/residual_generic_scalar_rbm.mpirun=1.output
@@ -10,8 +10,8 @@ Vector data:
 block 2: Process #0
 Local range: [0, 6), global size: 6
 Vector data:
--2.469e+00 -7.415e-01 -2.469e+00 -7.415e-01 1.261e+00 1.261e+00
+-8.393e-01 -7.415e-01 -8.393e-01 -7.415e-01 1.261e+00 1.261e+00
 block 3: Process #0
 Local range: [0, 6), global size: 6
 Vector data:
-1.261e+00 -7.415e-01 1.261e+00 -7.415e-01 -2.469e+00 -2.469e+00
+1.261e+00 -7.415e-01 1.261e+00 -7.415e-01 -8.393e-01 -8.393e-01

--- a/tests/residual_generic_scalar_rbm.mpirun=2.output
+++ b/tests/residual_generic_scalar_rbm.mpirun=2.output
@@ -10,7 +10,7 @@ Vector data:
 block 2: Process #0
 Local range: [0, 4), global size: 6
 Vector data:
--2.469e+00 -7.415e-01 -2.469e+00 -7.415e-01
+-8.393e-01 -7.415e-01 -8.393e-01 -7.415e-01
 block 3: Process #0
 Local range: [0, 4), global size: 6
 Vector data:
@@ -31,4 +31,4 @@ Vector data:
 block 3: Process #1
 Local range: [4, 6), global size: 6
 Vector data:
--2.469e+00 -2.469e+00
+-8.393e-01 -8.393e-01

--- a/tests/residual_generic_scalar_rbm.mpirun=3.output
+++ b/tests/residual_generic_scalar_rbm.mpirun=3.output
@@ -27,7 +27,7 @@ Vector data:
 block 2: Process #1
 Local range: [0, 4), global size: 6
 Vector data:
--2.469e+00 -7.415e-01 -2.469e+00 -7.415e-01
+-8.393e-01 -7.415e-01 -8.393e-01 -7.415e-01
 block 3: Process #1
 Local range: [0, 4), global size: 6
 Vector data:
@@ -48,4 +48,4 @@ Vector data:
 block 3: Process #2
 Local range: [4, 6), global size: 6
 Vector data:
--2.469e+00 -2.469e+00
+-8.393e-01 -8.393e-01

--- a/tests/residual_generic_tensorial_rbm.mpirun=1.output
+++ b/tests/residual_generic_tensorial_rbm.mpirun=1.output
@@ -10,8 +10,8 @@ Vector data:
 block 2: Process #0
 Local range: [0, 6), global size: 6
 Vector data:
--2.469e+00 -7.415e-01 -2.469e+00 -7.415e-01 1.261e+00 1.261e+00
+-8.393e-01 -7.415e-01 -8.393e-01 -7.415e-01 1.261e+00 1.261e+00
 block 3: Process #0
 Local range: [0, 6), global size: 6
 Vector data:
-1.261e+00 -7.415e-01 1.261e+00 -7.415e-01 -2.469e+00 -2.469e+00
+1.261e+00 -7.415e-01 1.261e+00 -7.415e-01 -8.393e-01 -8.393e-01

--- a/tests/residual_generic_tensorial_rbm.mpirun=2.output
+++ b/tests/residual_generic_tensorial_rbm.mpirun=2.output
@@ -10,7 +10,7 @@ Vector data:
 block 2: Process #0
 Local range: [0, 4), global size: 6
 Vector data:
--2.469e+00 -7.415e-01 -2.469e+00 -7.415e-01
+-8.393e-01 -7.415e-01 -8.393e-01 -7.415e-01
 block 3: Process #0
 Local range: [0, 4), global size: 6
 Vector data:
@@ -31,4 +31,4 @@ Vector data:
 block 3: Process #1
 Local range: [4, 6), global size: 6
 Vector data:
--2.469e+00 -2.469e+00
+-8.393e-01 -8.393e-01

--- a/tests/residual_generic_tensorial_rbm.mpirun=3.output
+++ b/tests/residual_generic_tensorial_rbm.mpirun=3.output
@@ -27,7 +27,7 @@ Vector data:
 block 2: Process #1
 Local range: [0, 4), global size: 6
 Vector data:
--2.469e+00 -7.415e-01 -2.469e+00 -7.415e-01
+-8.393e-01 -7.415e-01 -8.393e-01 -7.415e-01
 block 3: Process #1
 Local range: [0, 4), global size: 6
 Vector data:
@@ -48,4 +48,4 @@ Vector data:
 block 3: Process #2
 Local range: [4, 6), global size: 6
 Vector data:
--2.469e+00 -2.469e+00
+-8.393e-01 -8.393e-01


### PR DESCRIPTION
## Description

The advection term is slightly rewritten and it turned out that the new form keeps mass conservation whereas the previous one violated it. So, our advection term (will show it only for $c$) looks like this:
$-\nabla \cdot (c\mathbf{v}) = -\nabla c\cdot \mathbf{v} - c \nabla \cdot \mathbf{v}$
I have omitted the second term here since our velocities are constant within each grain (and seems to be an incorrent assumption that lead to the erroneous behavior). Keeping this assumption in mind, the weak form for the advection term was written as
$-\left(\nabla c\cdot \mathbf{v}, \phi_c \right)$
When studying the mass conservation I observed that it get violated. However, with this version of the advection term in the weak form, the mass conservation of the CH equation is preserved:
$\left(c \mathbf{v}, \nabla \phi_c \right)$
Here, as commonly done for $\nabla$-terms, the integration by parts was used with the divergence theorem (the boundary integral vanishes since the velocities are zero there). Note also the absence of the minus sign, this is not a typo.

## This is how the effect looks for a simple 2 particles test
### The mass conservation for the CH equation
![image](https://github.com/hpsint/hpsint/assets/8836201/bc40f801-98a0-4326-92b1-29b7922c44a9)
### The particles contours at the final timestep
![image](https://github.com/hpsint/hpsint/assets/8836201/6de65c2d-cb8f-46d6-8b62-97b347902e2b)
gray color - no advection
blue color - advection _old_ version
red color - advection _new_ version

## NB
I am not sure whether we should include this modification in the studies related for the paper. We do not have a lot of tests for advection and I am not sure whether the proposed modifications influence the performance of the advection related components of the sintering operator significantly. @peterrum, what do you think?