### PR TITLE
Customize normalization in OperatorAdvection

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/operator_advection.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_advection.h
@@ -367,13 +367,12 @@ namespace Sintering
                           auto etai_etaj = eta_i * eta_j;
 
                           // Disable this normalization
-                          /*
-                          etai_etaj      = compare_and_apply_mask<
-                            SIMDComparison::greater_than>(etai_etaj,
-                                                          cgb_lim,
-                                                          ones,
-                                                          zeros);
-                          */
+                          if (cgb >= 0)
+                            etai_etaj = compare_and_apply_mask<
+                              SIMDComparison::greater_than>(etai_etaj,
+                                                            cgb_lim,
+                                                            ones,
+                                                            zeros);
 
                           // Compute force component per cell
                           dF *= k * (c - ceq) * etai_etaj;

--- a/applications/sintering/include/pf-applications/sintering/parameters.h
+++ b/applications/sintering/include/pf-applications/sintering/parameters.h
@@ -174,7 +174,7 @@ namespace Sintering
     double k   = 100.;
     double mt  = 1.;
     double mr  = 1.;
-    double cgb = 0.1;
+    double cgb = -1;
     double ceq = 1.;
 
     bool check_courant = true;

--- a/tests/include/sintering_model.h
+++ b/tests/include/sintering_model.h
@@ -184,7 +184,7 @@ namespace Test
       sintering_data.time_data.set_all_dt(dts);
 
       double k   = 100;
-      double cgb = 0.1;
+      double cgb = -1;
       double ceq = 1.0;
 
       advection_operator =


### PR DESCRIPTION
It was a bit confusing that previously parameter `cgb` did not influence on anythig since the normalization was disabled in the code. I decided to bring it back in order to perform easier comparison with other researchers (because many people use it), but it still can be disabled (and that is the default behavior) if `cgb < 0`.