### PR TITLE
Smooth porosity contours

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/driver.h
+++ b/applications/sintering/include/pf-applications/sintering/driver.h
@@ -3047,7 +3047,8 @@ namespace Sintering
             output,
             params.output_data.n_coarsening_steps,
             box_filter,
-            params.output_data.n_mca_subdivisions);
+            params.output_data.n_mca_subdivisions,
+            params.output_data.porosity_smooth);
         }
 
       if (params.output_data.shrinkage)

--- a/applications/sintering/include/pf-applications/sintering/parameters.h
+++ b/applications/sintering/include/pf-applications/sintering/parameters.h
@@ -212,6 +212,7 @@ namespace Sintering
     unsigned int          n_mca_subdivisions     = 1;
     bool                  porosity               = false;
     bool                  porosity_contours      = false;
+    bool                  porosity_smooth        = true;
     bool                  porosity_stats         = false;
     double                porosity_max_value     = 0.8;
     bool                  shrinkage              = false;
@@ -799,6 +800,9 @@ namespace Sintering
       prm.add_parameter("PorosityContours",
                         output_data.porosity_contours,
                         "Output porosity contours to VTK.");
+      prm.add_parameter("PorositySmooth",
+                        output_data.porosity_smooth,
+                        "Whether to output smooth porosity to VTK.");
       prm.add_parameter("PorosityStats",
                         output_data.porosity_stats,
                         "Determine porosity and output its stats.");

--- a/applications/sintering/include/pf-applications/sintering/postprocessors.h
+++ b/applications/sintering/include/pf-applications/sintering/postprocessors.h
@@ -1856,11 +1856,14 @@ namespace Sintering
             cell->set_dof_values(values, pores_data.block(0));
         }
 
-      // This required for the MPI case
-      pores_data.compress(VectorOperation::add);
+      // This required for the MPI case for the non-smooth version
+      if (!smooth)
+        {
+          pores_data.compress(VectorOperation::add);
 
-      for (auto &v : pores_data.block(0))
-        v = std::min(v, 1.0);
+          for (auto &v : pores_data.block(0))
+            v = std::min(v, 1.0);
+        }
 
       output_concentration_contour_vtu(mapping,
                                        dof_handler,

--- a/applications/sintering/include/pf-applications/sintering/postprocessors.h
+++ b/applications/sintering/include/pf-applications/sintering/postprocessors.h
@@ -1729,6 +1729,7 @@ namespace Sintering
       const unsigned int                            n_coarsening_steps = 0,
       std::shared_ptr<const BoundingBoxFilter<dim>> box_filter     = nullptr,
       const unsigned int                            n_subdivisions = 1,
+      const bool                                    smooth         = true,
       const double                                  tolerance      = 1e-10)
     {
       const auto comm = dof_handler.get_communicator();
@@ -1803,7 +1804,9 @@ namespace Sintering
       // domain boundary. An alternative solution would be to process quantity
       // (1-c) but that generates sometimes not desirable output when the outer
       // void has to be eliminated. So this choice generates slightly less
-      // smooth but more physically representative surface contours.
+      // smooth but more physically representative surface contours. However,
+      // the option with smoother pores is also left as available since it
+      // provides better pictures if a bounding box filter was used.
       VectorType pores_data(1);
       const auto partitioner = std::make_shared<Utilities::MPI::Partitioner>(
         dof_handler.locally_owned_dofs(),
@@ -1811,13 +1814,26 @@ namespace Sintering
         dof_handler.get_communicator());
 
       pores_data.block(0).reinit(partitioner);
-      pores_data.block(0) = 0;
+
+      if (smooth)
+        {
+          // Use quantity (1-c)
+          pores_data.block(0).copy_locally_owned_data_from(solution.block(0));
+          pores_data.block(0) *= -1.0;
+          for (auto &v : pores_data.block(0))
+            v += 1.0;
+        }
+      else
+        {
+          // Use data from the pores info
+          pores_data.block(0) = 0;
+        }
 
       pores_data.update_ghost_values();
 
       Vector<typename VectorType::value_type> values(
         dof_handler.get_fe().n_dofs_per_cell());
-      values = 1.0;
+      values = (smooth ? 0.0 : 1.0);
 
       for (const auto &cell : dof_handler.active_cell_iterators())
         {
@@ -1833,7 +1849,10 @@ namespace Sintering
             local_to_global_pore_ids[static_cast<unsigned int>(pore_id) -
                                      offset];
 
-          if (boundary_pores.find(global_pore_id) == boundary_pores.end())
+          if ((boundary_pores.find(global_pore_id) != boundary_pores.end() &&
+               smooth) ||
+              (boundary_pores.find(global_pore_id) == boundary_pores.end() &&
+               !smooth))
             cell->set_dof_values(values, pores_data.block(0));
         }
 

--- a/applications/sintering/include/pf-applications/sintering/postprocessors.h
+++ b/applications/sintering/include/pf-applications/sintering/postprocessors.h
@@ -1837,6 +1837,12 @@ namespace Sintering
             cell->set_dof_values(values, pores_data.block(0));
         }
 
+      // This required for the MPI case
+      pores_data.compress(VectorOperation::add);
+
+      for (auto &v : pores_data.block(0))
+        v = std::min(v, 1.0);
+
       output_concentration_contour_vtu(mapping,
                                        dof_handler,
                                        pores_data,


### PR DESCRIPTION
When the bounding box filter is used, then porosity contours generated from the quantity (1-c) look better than those based on the pore ids. I decided to keep two options available and one can choose the desirable output manually.

![image](https://github.com/hpsint/hpsint/assets/8836201/48a72c88-5982-44e7-8b4e-63f97e1bbcb0)
