### PR TITLE
Reset all manifolds

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/postprocessors.h
+++ b/applications/sintering/include/pf-applications/sintering/postprocessors.h
@@ -1033,6 +1033,7 @@ namespace Sintering
               vector_order_parameter_id[cell->active_cell_index()] =
                 cell->manifold_id();
             }
+          tria.reset_all_manifolds();
         }
       else
         {


### PR DESCRIPTION
With the recent deal.II builds this exception started to be triggered in debug https://github.com/dealii/dealii/blob/7fd45dbe84557fd597724d8758e47d1a33c1653f/source/fe/mapping_fe.cc#L2279-L2282 inside `output_grain_contours_vtu()`. This is beacuse another branch of the "if" condition started to work here https://github.com/dealii/dealii/blob/7fd45dbe84557fd597724d8758e47d1a33c1653f/source/fe/fe_values.cc#L333, I guess that the default `update_flags` got changed somewhere (since we do not set the up in the contours output) and the influenced the default behavior of `DataOut`.