### PR TITLE
Multiple control boxes

### DIFF
--- a/applications/sintering/analysis_examples/termuhlen.json
+++ b/applications/sintering/analysis_examples/termuhlen.json
@@ -82,16 +82,9 @@
         "Regular": "false",
         "Shrinkage": "true",
         "Table": "true",
-        "UseControlBox": "true",
+        "OnlyControlBoxes": "true",
         "VtkPath": ".",
-        "ControlBox": {
-            "Xmin": "5",
-            "Xmax": "195",
-            "Ymin": "5",
-            "Ymax": "295",
-            "Zmin": "2.5",
-            "Zmax": "25"
-        }
+        "ControlBoxes": "5,5,5 ; 195,295,25"
     },
     "Preconditioners": {
         "OuterPreconditioner": "BlockPreconditioner2",

--- a/include/pf-applications/grid/bounding_box_filter.h
+++ b/include/pf-applications/grid/bounding_box_filter.h
@@ -165,6 +165,12 @@ namespace dealii
       return n_inside < cell.n_vertices() && n_outside < cell.n_vertices();
     }
 
+    const BoundingBox<dim, Number> &
+    get_bounding_box() const
+    {
+      return bounding_box;
+    }
+
   private:
     const BoundingBox<dim, Number> bounding_box;
     std::array<Plane, 2 * dim>     planes;


### PR DESCRIPTION
Sometimes I need to compute various quantities in various volumes of interest (control boxes) within the same simulation. The output is adjusted such that for the same run one can have multiple control boxes and also output quantities for the whole domain. Previously it was either the whole domain or the given control box.
```json
{
  "OnlyControlBoxes": "false",
  "ControlBoxes": "2,2,-4 ; 27.5,32,4 | 4,5,4 ; 25,27,4"
}
```

The option `OnlyControlBoxes=false` disables the output only for the control boxes, meaning that the quantities and/or contours will be built also for the entire domain. By default is set to `false`.

The option `ControlBoxes` in the case above defines 2 volumes of interest with the `bottom_left x top_right` points as follows:
1. (2, 2, -4) x (27.5, 32, 4)
2. (4, 5, 4) x (25, 27, 4)

Note that here points are always defined in 3D. This is done in order to use the same input file for both 2D and 3D runs.