### PR TITLE
Remove assert tranfser grain ids

### DIFF
--- a/include/pf-applications/grain_tracker/tracking.h
+++ b/include/pf-applications/grain_tracker/tracking.h
@@ -148,32 +148,27 @@ namespace GrainTracker
                   const auto it_old_to_new =
                     old_grains_to_new.find(old_grain_id);
 
-                  if (it_old_to_new != old_grains_to_new.end())
+                  // Create "new -> old" and "old -> new" mappings. The latter
+                  // is always checked to ensure that the mapping "new -> old"
+                  // is unambiguous, i.e. an old grain can be mapped only to one
+                  // new grain.
+                  if (it_old_to_new == old_grains_to_new.end())
                     {
-                      std::ostringstream ss;
-                      ss << "Mapping conflict has been detected." << std::endl;
-                      ss << "An old grain is mapped at least to 2 new grains:"
-                         << std::endl;
-                      ss << std::endl;
-
-                      ss << "old grain:" << std::endl;
-                      print_grain(old_grains.at(old_grain_id), ss);
-                      ss << std::endl;
-
-                      ss << "new grain 1:" << std::endl;
-                      print_grain(new_grains.at(it_old_to_new->second), ss);
-                      ss << std::endl;
-
-                      ss << "new grain 2:" << std::endl;
-                      print_grain(new_grains.at(grain_id), ss);
-
-                      // Thrown an exception
-                      AssertThrow(it_old_to_new == old_grains_to_new.end(),
-                                  ExcGrainsInconsistency(ss.str()));
+                      // Add new mapping if it does not exist yet
+                      new_grains_to_old.at(grain_id) = old_grain_id;
+                      old_grains_to_new.try_emplace(old_grain_id, grain_id);
                     }
-
-                  new_grains_to_old.at(grain_id) = old_grain_id;
-                  old_grains_to_new.try_emplace(old_grain_id, grain_id);
+                  else if (new_grains.at(grain_id).get_max_value() >
+                           new_grains.at(it_old_to_new->second).get_max_value())
+                    {
+                      // Overwrite the existing mapping if a newly detected
+                      // candidate grain has a larger max_value than the one
+                      // mapped previously
+                      new_grains_to_old.at(it_old_to_new->second) =
+                        numbers::invalid_unsigned_int;
+                      new_grains_to_old.at(grain_id)     = old_grain_id;
+                      old_grains_to_new.at(old_grain_id) = grain_id;
+                    }
 
                   break;
                 }

--- a/tests/transfer_grain_ids_08.cc
+++ b/tests/transfer_grain_ids_08.cc
@@ -23,7 +23,7 @@ using namespace GrainTracker;
 int
 main()
 {
-  // Map 2 old grains to 2 new grains: multisegments
+  // Map 2 old grains to 1 new grain: a nearly conflict case
 
   constexpr unsigned int dim = 2;
 

--- a/tests/transfer_grain_ids_09.cc
+++ b/tests/transfer_grain_ids_09.cc
@@ -23,7 +23,7 @@ using namespace GrainTracker;
 int
 main()
 {
-  // Map 2 old grains to 2 new grains: multisegments
+  // Map 7 old grains to 7 new grains
 
   constexpr unsigned int dim = 3;
 

--- a/tests/transfer_grain_ids_11.cc
+++ b/tests/transfer_grain_ids_11.cc
@@ -23,57 +23,69 @@ using namespace GrainTracker;
 int
 main()
 {
-  // Map 3 old grains to 4 new grains: 1 new appeared, 2 order parameters used
+  // Map 3 old grains to 5 new grains: 2 new appeared, a conflict between the
+  // new grains
 
   constexpr unsigned int dim = 2;
 
   std::map<unsigned int, Grain<dim>> old_grains;
 
-  old_grains.try_emplace(4, 4, 0);
-  old_grains.at(4).add_segment(Point<dim>(0, 0),
-                               2.0,
-                               std::pow(2.0, 2) * M_PI,
-                               1.0);
+  old_grains.try_emplace(14, 14, 0);
+  old_grains.at(14).add_segment(Point<dim>(0, 0),
+                                2.0,
+                                std::pow(2.0, 2) * M_PI,
+                                1.0);
 
-  old_grains.try_emplace(6, 6, 1);
-  old_grains.at(6).add_segment(Point<dim>(8, 0),
-                               3.0,
-                               std::pow(3.0, 2) * M_PI,
-                               1.0);
+  old_grains.try_emplace(12, 12, 0);
+  old_grains.at(12).add_segment(Point<dim>(8, 0),
+                                3.0,
+                                std::pow(3.0, 2) * M_PI,
+                                1.0);
 
-  old_grains.try_emplace(7, 7, 0);
-  old_grains.at(7).add_segment(Point<dim>(2, -9),
-                               1.0,
-                               std::pow(1.0, 2) * M_PI,
-                               1.0);
+  old_grains.try_emplace(17, 17, 0);
+  old_grains.at(17).add_segment(Point<dim>(2, -9),
+                                1.0,
+                                std::pow(1.0, 2) * M_PI,
+                                1.0);
 
   std::map<unsigned int, Grain<dim>> new_grains;
 
+  // This grain is in conflict with grain 4 to be mapped to grain 14
   new_grains.try_emplace(0, 0, 0);
-  new_grains.at(0).add_segment(Point<dim>(1, 1),
-                               1.7,
-                               std::pow(1.7, 2) * M_PI,
-                               1.0);
+  new_grains.at(0).add_segment(Point<dim>(1.9, 1.9),
+                               0.12,
+                               std::pow(0.12, 2) * M_PI,
+                               0.015);
 
-  new_grains.try_emplace(2, 2, 1);
+  // This should be mapped to 12
+  new_grains.try_emplace(2, 2, 0);
   new_grains.at(2).add_segment(Point<dim>(7, 1),
                                3.2,
                                std::pow(3.2, 2) * M_PI,
                                1.0);
 
+  // This should be mapped to 17
   new_grains.try_emplace(1, 1, 0);
   new_grains.at(1).add_segment(Point<dim>(3, -8),
                                1.2,
                                std::pow(1.2, 2) * M_PI,
                                1.0);
 
-  new_grains.try_emplace(3, 3, 1);
+  // This is a valid new grain
+  new_grains.try_emplace(3, 3, 0);
   new_grains.at(3).add_segment(Point<dim>(7, -6),
                                0.9,
                                std::pow(0.9, 2) * M_PI,
                                1.0);
 
-  const unsigned int n_order_params = 2;
+  // This should be mapped to 14
+  new_grains.try_emplace(4, 4, 0);
+  new_grains.at(4).add_segment(Point<dim>(1, 1),
+                               1.7,
+                               std::pow(1.7, 2) * M_PI,
+                               1.0);
+
+  const unsigned int n_order_params = 1;
 
   const auto new_grains_to_old =
     transfer_grain_ids(new_grains, old_grains, n_order_params);

--- a/tests/transfer_grain_ids_11.output
+++ b/tests/transfer_grain_ids_11.output
@@ -1,0 +1,8 @@
+# of old grains = 3
+# of new grains = 5
+Grains mapping (new_id -> old_id):
+0 -> 4294967295
+1 -> 17
+2 -> 12
+3 -> 4294967295
+4 -> 14


### PR DESCRIPTION
Instead of throwing an exception as was introduced in #606, it is better to overwrite a mapping if a better suited condidate has been identified. Such situations can appear, for instance, if a tiny grain looking area was identified because its max value was above the detection `threshold_lower`. Such an area can be neighboring to a real grain. The proposed modification ensures that a real grain is chosen for mapping and not this tiny area. Therefore, such an area will be identified as a new grain but will be always then dropped out in `track()` since its max value is lower than `threshold_new_grains`.