### PR TITLE
Customize grain tracker logging

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/driver.h
+++ b/applications/sintering/include/pf-applications/sintering/driver.h
@@ -1726,7 +1726,9 @@ namespace Sintering
         ScopedName sc("run_grain_tracker");
         MyScope    scope(timer, sc);
 
-        pcout << "Execute grain tracker:" << std::endl;
+        pcout << "Execute grain tracker("
+              << (do_initialize ? "initial_setup" : "track")
+              << "):" << std::endl;
 
         system_has_changed = true;
 

--- a/applications/sintering/include/pf-applications/sintering/driver.h
+++ b/applications/sintering/include/pf-applications/sintering/driver.h
@@ -2166,10 +2166,13 @@ namespace Sintering
                         pcout << "\033[31m"
                               << "The errors appeared while matching the grains"
                               << "\033[0m" << std::endl;
-                        pcout
-                          << "The list of grains from the previous successful GT run:"
-                          << std::endl;
+                        pcout << "Grains from the previous successful GT run:"
+                              << std::endl;
                         grain_tracker.print_old_grains(pcout);
+
+                        pcout << "Grains which were successfully assigned:"
+                              << std::endl;
+                        grain_tracker.print_current_grains(pcout);
 
                         AssertThrow(false, ExcMessage(ex.what()));
                       }

--- a/applications/sintering/include/pf-applications/sintering/parameters.h
+++ b/applications/sintering/include/pf-applications/sintering/parameters.h
@@ -91,6 +91,7 @@ namespace Sintering
     double       buffer_distance_ratio   = 0.05;
     double       buffer_distance_fixed   = 0.0;
     unsigned int grain_tracker_frequency = 10; // 0 - no grain tracker
+    unsigned int verbosity               = 0;
 
     bool fast_reassignment  = false;
     bool track_with_quality = false;
@@ -586,6 +587,9 @@ namespace Sintering
       prm.add_parameter("GrainTrackerFrequency",
                         grain_tracker_data.grain_tracker_frequency,
                         "Grain tracker frequency (0 = no grain tracking).");
+      prm.add_parameter("Verbosity",
+                        grain_tracker_data.verbosity,
+                        "Grain tracker verbosity level.");
       prm.add_parameter("FastReassignment",
                         grain_tracker_data.fast_reassignment,
                         "Use fast grain reassignment strategy.");

--- a/include/pf-applications/grain_tracker/tracker.h
+++ b/include/pf-applications/grain_tracker/tracker.h
@@ -257,15 +257,8 @@ namespace GrainTracker
         {
           std::ostringstream ss;
           ss << "Unable to match some new grains with old ones "
-             << "from the previous configuration!" << std::endl;
-          ss << std::endl;
-
-          ss << "Problematic grains:" << std::endl;
+             << "from the previous configuration:" << std::endl;
           print_grains(invalid_grains, ss);
-          ss << std::endl;
-
-          ss << "Grains which were successfully assigned:" << std::endl;
-          print_grains(grains, ss);
 
           // Thrown an exception
           AssertThrow(invalid_grains.empty(), ExcGrainsInconsistency(ss.str()));

--- a/include/pf-applications/grain_tracker/tracking.h
+++ b/include/pf-applications/grain_tracker/tracking.h
@@ -48,10 +48,10 @@ namespace GrainTracker
   template <int dim>
   std::map<unsigned int, unsigned int>
   transfer_grain_ids(
-    const std::map<unsigned int, Grain<dim>> &               new_grains,
-    const std::map<unsigned int, Grain<dim>> &               old_grains,
-    const unsigned int                                       n_order_params,
-    std::optional<std::reference_wrapper<std::stringstream>> logger = {})
+    const std::map<unsigned int, Grain<dim>> &          new_grains,
+    const std::map<unsigned int, Grain<dim>> &          old_grains,
+    const unsigned int                                  n_order_params,
+    std::optional<std::reference_wrapper<std::ostream>> logger = {})
   {
     // This algorithm works now only for grains with a single segment
     namespace bgi = boost::geometry::index;

--- a/include/pf-applications/grain_tracker/tracking.h
+++ b/include/pf-applications/grain_tracker/tracking.h
@@ -19,6 +19,9 @@
 
 #include <pf-applications/base/geometry.h>
 
+#include <functional>
+#include <optional>
+
 #include "grain.h"
 #include "output.h"
 
@@ -44,9 +47,11 @@ namespace GrainTracker
   // Advanced ids assignment algo based on rtrees
   template <int dim>
   std::map<unsigned int, unsigned int>
-  transfer_grain_ids(const std::map<unsigned int, Grain<dim>> &new_grains,
-                     const std::map<unsigned int, Grain<dim>> &old_grains,
-                     const unsigned int                        n_order_params)
+  transfer_grain_ids(
+    const std::map<unsigned int, Grain<dim>> &               new_grains,
+    const std::map<unsigned int, Grain<dim>> &               old_grains,
+    const unsigned int                                       n_order_params,
+    std::optional<std::reference_wrapper<std::stringstream>> logger = {})
   {
     // This algorithm works now only for grains with a single segment
     namespace bgi = boost::geometry::index;
@@ -147,6 +152,40 @@ namespace GrainTracker
                   // Check if mapping already exists
                   const auto it_old_to_new =
                     old_grains_to_new.find(old_grain_id);
+
+                  // Log the mapping conflicts resolution
+                  if (logger && it_old_to_new != old_grains_to_new.end())
+                    {
+                      auto &ss = logger->get();
+
+                      ss << "Mapping conflict \"old -> new\" has been detected"
+                         << std::endl;
+                      ss << "  existing mapping: " << old_grain_id << " -> "
+                         << it_old_to_new->second << std::endl;
+                      ss << " candidate mapping: " << old_grain_id << " -> "
+                         << grain_id << std::endl;
+                      ss << "old grain:" << std::endl;
+                      print_grain(old_grains.at(old_grain_id), ss);
+
+                      ss << "new grain already mapped:" << std::endl;
+                      print_grain(new_grains.at(it_old_to_new->second), ss);
+
+                      ss << "new grain candidate for mapping:" << std::endl;
+                      print_grain(new_grains.at(grain_id), ss);
+
+                      // This check appears below too, it was decided to
+                      // separate loggin logic to the independent block for the
+                      // code clarity
+                      if (new_grains.at(grain_id).get_max_value() >
+                          new_grains.at(it_old_to_new->second).get_max_value())
+                        ss
+                          << "The existing mapping was overwritten with the candidate."
+                          << std::endl;
+                      else
+                        ss
+                          << "The existing mapping was kept and the candidate was omitted."
+                          << std::endl;
+                    }
 
                   // Create "new -> old" and "old -> new" mappings. The latter
                   // is always checked to ensure that the mapping "new -> old"

--- a/tests/transfer_grain_ids_12.cc
+++ b/tests/transfer_grain_ids_12.cc
@@ -1,0 +1,84 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2023 by the hpsint authors
+//
+// This file is part of the hpsint library.
+//
+// The hpsint library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.MD at
+// the top level directory of hpsint.
+//
+// ---------------------------------------------------------------------
+
+#include <deal.II/base/mpi.h>
+
+#include <pf-applications/grain_tracker/tracking.h>
+
+using namespace dealii;
+using namespace GrainTracker;
+
+int
+main()
+{
+  // Map 2 old grains to 3 new grains: a conflict between the new grains and
+  // also check debugging output in the situation when the mapping is
+  // overwritten.
+
+  constexpr unsigned int dim = 2;
+
+  std::map<unsigned int, Grain<dim>> old_grains;
+
+  old_grains.try_emplace(14, 14, 0);
+  old_grains.at(14).add_segment(Point<dim>(0, 0),
+                                2.0,
+                                std::pow(2.0, 2) * M_PI,
+                                1.0);
+
+  old_grains.try_emplace(12, 12, 0);
+  old_grains.at(12).add_segment(Point<dim>(8, 0),
+                                3.0,
+                                std::pow(3.0, 2) * M_PI,
+                                1.0);
+
+  std::map<unsigned int, Grain<dim>> new_grains;
+
+  // This grain is in conflict with grain 4 to be mapped to grain 14
+  new_grains.try_emplace(0, 0, 0);
+  new_grains.at(0).add_segment(Point<dim>(1.9, 1.9),
+                               0.12,
+                               std::pow(0.12, 2) * M_PI,
+                               0.015);
+
+  // This should be mapped to 12
+  new_grains.try_emplace(2, 2, 0);
+  new_grains.at(2).add_segment(Point<dim>(7, 1),
+                               3.2,
+                               std::pow(3.2, 2) * M_PI,
+                               1.0);
+
+  // This should be mapped to 14
+  new_grains.try_emplace(4, 4, 0);
+  new_grains.at(4).add_segment(Point<dim>(1, 1),
+                               1.7,
+                               std::pow(1.7, 2) * M_PI,
+                               1.0);
+
+  const unsigned int n_order_params = 1;
+
+  std::stringstream ss;
+
+  const auto new_grains_to_old =
+    transfer_grain_ids(new_grains, old_grains, n_order_params, ss);
+
+  std::cout << ss.str();
+
+  std::cout << "# of old grains = " << old_grains.size() << std::endl;
+  std::cout << "# of new grains = " << new_grains.size() << std::endl;
+
+  std::cout << "Grains mapping (new_id -> old_id):" << std::endl;
+  for (const auto &[new_id, old_id] : new_grains_to_old)
+    std::cout << new_id << " -> " << old_id << std::endl;
+}

--- a/tests/transfer_grain_ids_12.output
+++ b/tests/transfer_grain_ids_12.output
@@ -1,0 +1,19 @@
+Mapping conflict "old -> new" has been detected
+  existing mapping: 14 -> 0
+ candidate mapping: 14 -> 4
+old grain:
+op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 14
+    segment: center = 0 0 | radius = 2 | max_value = 1
+new grain already mapped:
+op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 0
+    segment: center = 1.9 1.9 | radius = 0.12 | max_value = 0.015
+new grain candidate for mapping:
+op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 4
+    segment: center = 1 1 | radius = 1.7 | max_value = 1
+The existing mapping was overwritten with the candidate.
+# of old grains = 2
+# of new grains = 3
+Grains mapping (new_id -> old_id):
+0 -> 4294967295
+2 -> 12
+4 -> 14

--- a/tests/transfer_grain_ids_13.cc
+++ b/tests/transfer_grain_ids_13.cc
@@ -1,0 +1,84 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2023 by the hpsint authors
+//
+// This file is part of the hpsint library.
+//
+// The hpsint library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.MD at
+// the top level directory of hpsint.
+//
+// ---------------------------------------------------------------------
+
+#include <deal.II/base/mpi.h>
+
+#include <pf-applications/grain_tracker/tracking.h>
+
+using namespace dealii;
+using namespace GrainTracker;
+
+int
+main()
+{
+  // Map 2 old grains to 3 new grains: a conflict between the new grains and
+  // also check debugging output in the situation when the mapping is not
+  // overwritten.
+
+  constexpr unsigned int dim = 2;
+
+  std::map<unsigned int, Grain<dim>> old_grains;
+
+  old_grains.try_emplace(14, 14, 0);
+  old_grains.at(14).add_segment(Point<dim>(0, 0),
+                                2.0,
+                                std::pow(2.0, 2) * M_PI,
+                                1.0);
+
+  old_grains.try_emplace(12, 12, 0);
+  old_grains.at(12).add_segment(Point<dim>(8, 0),
+                                3.0,
+                                std::pow(3.0, 2) * M_PI,
+                                1.0);
+
+  std::map<unsigned int, Grain<dim>> new_grains;
+
+  // This grain is in conflict with grain 4 to be mapped to grain 14
+  new_grains.try_emplace(5, 5, 0);
+  new_grains.at(5).add_segment(Point<dim>(1.9, 1.9),
+                               0.12,
+                               std::pow(0.12, 2) * M_PI,
+                               0.015);
+
+  // This should be mapped to 12
+  new_grains.try_emplace(2, 2, 0);
+  new_grains.at(2).add_segment(Point<dim>(7, 1),
+                               3.2,
+                               std::pow(3.2, 2) * M_PI,
+                               1.0);
+
+  // This should be mapped to 14
+  new_grains.try_emplace(4, 4, 0);
+  new_grains.at(4).add_segment(Point<dim>(1, 1),
+                               1.7,
+                               std::pow(1.7, 2) * M_PI,
+                               1.0);
+
+  const unsigned int n_order_params = 1;
+
+  std::stringstream ss;
+
+  const auto new_grains_to_old =
+    transfer_grain_ids(new_grains, old_grains, n_order_params, ss);
+
+  std::cout << ss.str();
+
+  std::cout << "# of old grains = " << old_grains.size() << std::endl;
+  std::cout << "# of new grains = " << new_grains.size() << std::endl;
+
+  std::cout << "Grains mapping (new_id -> old_id):" << std::endl;
+  for (const auto &[new_id, old_id] : new_grains_to_old)
+    std::cout << new_id << " -> " << old_id << std::endl;
+}

--- a/tests/transfer_grain_ids_13.output
+++ b/tests/transfer_grain_ids_13.output
@@ -1,0 +1,19 @@
+Mapping conflict "old -> new" has been detected
+  existing mapping: 14 -> 4
+ candidate mapping: 14 -> 5
+old grain:
+op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 14
+    segment: center = 0 0 | radius = 2 | max_value = 1
+new grain already mapped:
+op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 4
+    segment: center = 1 1 | radius = 1.7 | max_value = 1
+new grain candidate for mapping:
+op_index_current = 0 | op_index_old = 0 | segments = 1 | grain_index = 5
+    segment: center = 1.9 1.9 | radius = 0.12 | max_value = 0.015
+The existing mapping was kept and the candidate was omitted.
+# of old grains = 2
+# of new grains = 3
+Grains mapping (new_id -> old_id):
+2 -> 12
+4 -> 14
+5 -> 4294967295


### PR DESCRIPTION
Add some vorbisity levels in order to reduce the output details in certain cases.
Also some exceptions made more readable.

It would be better to use `LogStream`, but that is better to be properly implemented application-wise. So I took a simpler approach that does the job at the moment.