### PR TITLE
Use center instead of barycenter

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/postprocessors.h
+++ b/applications/sintering/include/pf-applications/sintering/postprocessors.h
@@ -2021,21 +2021,31 @@ namespace Sintering
 
               for (unsigned int d = 0; d < dim; ++d)
                 {
+                  const auto cell_coord = cell->center()[d];
+                  const auto min_coord  = min_cells[d].first->center()[d];
+                  const auto max_coord  = max_cells[d].first->center()[d];
+
+                  const auto dist_min =
+                    (min_cells[d].first.state() != IteratorState::invalid) ?
+                      std::abs(cell_coord - min_coord) :
+                      0.;
+
                   if (min_cells[d].first.state() == IteratorState::invalid ||
-                      (std::abs(cell->center()[d] -
-                                min_cells[d].first->center()[d]) < abs_tol &&
-                       c_norm > min_cells[d].second) ||
-                      cell->center()[d] < min_cells[d].first->center()[d])
+                      (dist_min < abs_tol && c_norm > min_cells[d].second) ||
+                      (dist_min > abs_tol && cell_coord < min_coord))
                     {
                       min_cells[d].first  = cell;
                       min_cells[d].second = c_norm;
                     }
 
+                  const auto dist_max =
+                    (max_cells[d].first.state() != IteratorState::invalid) ?
+                      std::abs(cell_coord - max_coord) :
+                      0.;
+
                   if (max_cells[d].first.state() == IteratorState::invalid ||
-                      (std::abs(cell->center()[d] -
-                                max_cells[d].first->center()[d]) < abs_tol &&
-                       c_norm > max_cells[d].second) ||
-                      cell->center()[d] > max_cells[d].first->center()[d])
+                      (dist_max < abs_tol && c_norm > max_cells[d].second) ||
+                      (dist_max > abs_tol && cell_coord > max_coord))
                     {
                       max_cells[d].first  = cell;
                       max_cells[d].second = c_norm;

--- a/applications/sintering/include/pf-applications/sintering/postprocessors.h
+++ b/applications/sintering/include/pf-applications/sintering/postprocessors.h
@@ -1961,7 +1961,7 @@ namespace Sintering
                        const unsigned int     n_intervals = 10)
     {
       const double threshold = 0.5 - 1e-2;
-      const double abs_tol   = 1e-15;
+      const double rel_tol   = 1e-3;
 
       FEValues<dim> fe_values(mapping,
                               dof_handler.get_fe(),
@@ -2016,29 +2016,26 @@ namespace Sintering
                             return val < threshold;
                           }))
             {
-              const double c_norm = values.linfty_norm();
+              const double c_norm  = values.linfty_norm();
+              const double abs_tol = rel_tol * cell->diameter();
 
               for (unsigned int d = 0; d < dim; ++d)
                 {
                   if (min_cells[d].first.state() == IteratorState::invalid ||
-                      (std::abs(cell->barycenter()[d] -
-                                min_cells[d].first->barycenter()[d]) <
-                         abs_tol &&
+                      (std::abs(cell->center()[d] -
+                                min_cells[d].first->center()[d]) < abs_tol &&
                        c_norm > min_cells[d].second) ||
-                      cell->barycenter()[d] <
-                        min_cells[d].first->barycenter()[d])
+                      cell->center()[d] < min_cells[d].first->center()[d])
                     {
                       min_cells[d].first  = cell;
                       min_cells[d].second = c_norm;
                     }
 
                   if (max_cells[d].first.state() == IteratorState::invalid ||
-                      (std::abs(cell->barycenter()[d] -
-                                max_cells[d].first->barycenter()[d]) <
-                         abs_tol &&
+                      (std::abs(cell->center()[d] -
+                                max_cells[d].first->center()[d]) < abs_tol &&
                        c_norm > max_cells[d].second) ||
-                      cell->barycenter()[d] >
-                        max_cells[d].first->barycenter()[d])
+                      cell->center()[d] > max_cells[d].first->center()[d])
                     {
                       max_cells[d].first  = cell;
                       max_cells[d].second = c_norm;


### PR DESCRIPTION
In relation to #234.
It turned out that `center()` provides more accurate results than `barycenter()`. These inaccuracies led to wrong estimates of shrinkage.

With `barycenter()`:
![with_barycenter](https://github.com/hpsint/hpsint/assets/8836201/dbf0193c-c5a4-4f13-9aa0-fcd3268ac038)

With `center()`:
![with_center](https://github.com/hpsint/hpsint/assets/8836201/4bf02140-1eb0-48bd-9472-7103e635a10b)

I also made tolerance to be relevant to the cell size.
