### PR TITLE
[WIP] Script to mass copy results

### DIFF
--- a/applications/sintering/scripts/copy_results.py
+++ b/applications/sintering/scripts/copy_results.py
@@ -1,0 +1,80 @@
+import shutil
+import argparse
+import glob
+import re
+import os
+import pathlib
+import library
+
+parser = argparse.ArgumentParser(description='Mass copy the results:')
+parser.add_argument("-s", "--source", type=str, help="Source path, can be a mask", required=True)
+parser.add_argument("-d", "--destination", type=str, help="Destination path", required=True)
+parser.add_argument("-f", "--file", nargs='+', help="What files to copy", required=False, default="solution.log")
+parser.add_argument("-j", "--job-extension", type=str, help="Job file extension", required=False, default="out")
+parser.add_argument("-a", "--job-all", action='store_true', help="Copy all job files", required=False, default=False)
+parser.add_argument("-c", "--clean", action='store_true', help="Clean destination folder", required=False, default=False)
+
+args = parser.parse_args()
+
+# Get files according to the mask and sort them by number
+folders_list = glob.glob(args.source)
+folders_list.sort(key=lambda f: int(re.sub('\D', '', f)))
+
+# List of destionation folders, can be a single one
+all_dst_folders = []
+
+for folder in folders_list:
+
+    print("Copying data from folder {}".format(folder))
+
+    if not os.path.isdir(folder):
+        raise Exception('The provided path mask should capture folders only')
+    
+    folder_this = pathlib.PurePath(folder).name
+    folder_parent = pathlib.PurePath(folder).parent.name
+    
+    # %0 - immediate parent dir
+    # %1 - parent of the parent dir
+    output_path = args.destination
+    output_path = output_path.replace("%0", folder_this)
+    output_path = output_path.replace("%1", folder_parent)
+
+    folder_dst = os.path.dirname(output_path + "dummy.txt")
+
+    if folder_dst not in all_dst_folders:
+        all_dst_folders.append(folder_dst)
+        if args.clean and os.path.isdir(folder_dst):
+            library.clean_folder(folder_dst)
+    
+    for mask in args.file:
+        ff = os.path.join(folder, mask)
+        files_list = glob.glob(os.path.join(folder, mask))
+        files_list.sort(key=os.path.getmtime)
+
+        for file_src in files_list:
+            filename, file_extension = os.path.splitext(file_src)
+            file_extension = file_extension[1:]
+            base_name = os.path.basename(file_src)
+
+            skip_the_rest = False
+
+            # If we copy all job files, then we do not rename it
+            if file_extension == args.job_extension:
+                if args.job_all:
+                    file_dst = os.path.join(folder_dst, base_name)
+                else:
+                    parts = base_name.split('.')
+                    parts.pop(0)
+                    file_dst = output_path + ".".join(parts)
+
+                    # Skip the rest of the job files
+                    skip_the_rest = True
+            else:
+                file_dst = output_path + base_name
+            
+            pathlib.Path(os.path.dirname(file_dst)).mkdir(parents=True, exist_ok=True)
+            shutil.copy2(file_src, file_dst)
+            print("  {} -> {}".format(base_name, file_dst))
+
+            if skip_the_rest:
+                break

--- a/applications/sintering/scripts/library.py
+++ b/applications/sintering/scripts/library.py
@@ -153,3 +153,14 @@ def animation_format_plot(ax, main_color, background_color, ticks_size, axes_lab
     ax.set_facecolor(background_color)
     ax.xaxis.label.set_size(axes_label_size)
     ax.yaxis.label.set_size(axes_label_size)
+
+def clean_folder(folder):
+    for filename in os.listdir(folder):
+        file_path = os.path.join(folder, filename)
+        try:
+            if os.path.isfile(file_path) or os.path.islink(file_path):
+                os.unlink(file_path)
+            elif os.path.isdir(file_path):
+                shutil.rmtree(file_path)
+        except Exception as e:
+            print('Failed to delete %s. Reason: %s' % (file_path, e))


### PR DESCRIPTION
It is a common need to copy certain output files from multiple folders when preparing a paper.

For example, I have performed analysis of chains of N particles for `N=2,4,6,8`. I need to copy everything in one place.

```
vladimir@ubuntu:~$ python copy_results.py -s "/home/vladimir/supermuc_work/studies/coupled_wang/output/hypercube_10x*x1/2d_generic_wang_debug" -d /mnt/x/send/%1_%0_ -f solution.log solution_shrinkage.csv *.out -c
Copying data from folder /home/vladimir/work/supermuc_work/studies/coupled_wang/output/hypercube_10x2x1/2d_generic_wang_debug
  solution.log -> /mnt/x/send/test/hypercube_10x2x1_2d_generic_wang_debug_solution.log
  solution_shrinkage.csv -> /mnt/x/send/test/hypercube_10x2x1_2d_generic_wang_debug_solution_shrinkage.csv
  cou_hypercube_10x2x1_debug_2d_genwang_s.3282261.out -> /mnt/x/send/test/hypercube_10x2x1_2d_generic_wang_debug_3282261.out
Copying data from folder /home/vladimir/work/supermuc_work/studies/coupled_wang/output/hypercube_10x4x1/2d_generic_wang_debug
  solution.log -> /mnt/x/send/test/hypercube_10x4x1_2d_generic_wang_debug_solution.log
  solution_shrinkage.csv -> /mnt/x/send/test/hypercube_10x4x1_2d_generic_wang_debug_solution_shrinkage.csv
  cou_hypercube_10x4x1_debug_2d_genwang_s.3282262.out -> /mnt/x/send/test/hypercube_10x4x1_2d_generic_wang_debug_3282262.out
Copying data from folder /home/vladimir/work/supermuc_work/studies/coupled_wang/output/hypercube_10x6x1/2d_generic_wang_debug
  solution.log -> /mnt/x/send/test/hypercube_10x6x1_2d_generic_wang_debug_solution.log
  solution_shrinkage.csv -> /mnt/x/send/test/hypercube_10x6x1_2d_generic_wang_debug_solution_shrinkage.csv
  cou_hypercube_10x6x1_debug_2d_genwang_s.3282263.out -> /mnt/x/send/test/hypercube_10x6x1_2d_generic_wang_debug_3282263.out
Copying data from folder /home/vladimir/work/supermuc_work/studies/coupled_wang/output/hypercube_10x8x1/2d_generic_wang_debug
  solution.log -> /mnt/x/send/test/hypercube_10x8x1_2d_generic_wang_debug_solution.log
  solution_shrinkage.csv -> /mnt/x/send/test/hypercube_10x8x1_2d_generic_wang_debug_solution_shrinkage.csv
  cou_hypercube_10x8x1_debug_2d_genwang_s.3282264.out -> /mnt/x/send/test/hypercube_10x8x1_2d_generic_wang_debug_3282264.out
```

`%0` and so one are special shortcuts for the parental folders names: 0 - the immediate parent, 1 - parent of a parent and so on.