### PR TITLE
Call grain tracker initialization if `track_with_quality = true`

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/driver.h
+++ b/applications/sintering/include/pf-applications/sintering/driver.h
@@ -2061,6 +2061,7 @@ namespace Sintering
 
       // Grain tracker - first run after we have initial configuration defined
       if (params.grain_tracker_data.grain_tracker_frequency > 0 ||
+          params.grain_tracker_data.track_with_quality ||
           params.advection_data.enable)
         run_grain_tracker(t, /*do_initialize = */ true);
 

--- a/include/pf-applications/grain_tracker/tracker.h
+++ b/include/pf-applications/grain_tracker/tracker.h
@@ -148,7 +148,8 @@ namespace GrainTracker
         detect_grains(solution, n_order_params, assign_indices);
 
       // Numberer for new grains
-      unsigned int grain_numberer = old_grains.rbegin()->first + 1;
+      unsigned int grain_numberer =
+        (!old_grains.empty()) ? (old_grains.rbegin()->first + 1) : 0;
 
       // Create map with the grains whose ids have been changed
       std::vector<std::vector<bool>> grains_ids_changed(


### PR DESCRIPTION
Also fix counter initialization if `old_grains` map is empty.