### PR TITLE
Courant fix `precompute_cell_diameters()` calls

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/driver.h
+++ b/applications/sintering/include/pf-applications/sintering/driver.h
@@ -2050,6 +2050,9 @@ namespace Sintering
                                                 bottom_fraction_of_cells);
               initialize_solution(solution_ptr, timer);
             }
+
+          if (n_init_refinements == 0)
+            advection_operator.precompute_cell_diameters();
         }
       else if (params.advection_data.enable &&
                params.advection_data.check_courant)

--- a/applications/sintering/include/pf-applications/sintering/operator_advection.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_advection.h
@@ -144,10 +144,14 @@ namespace Sintering
                     "advection_op::check_courant",
                     this->do_timing);
 
-      AssertThrow(cell_diameters.size() == this->matrix_free.n_cell_batches(),
-                  ExcMessage(
-                    "The number of precomputed cell diameters is inconsistent"
-                    " with the number of current cell batches"));
+      AssertThrow(
+        cell_diameters.size() == this->matrix_free.n_cell_batches(),
+        ExcMessage(
+          std::string(
+            "The number of precomputed cell diameters is inconsistent") +
+          std::string(" with the number of current cell batches: ") +
+          std::to_string(cell_diameters.size()) + std::string(" and ") +
+          std::to_string(this->matrix_free.n_cell_batches())));
 
       FECellIntegrator<dim, 1, Number, VectorizedArrayType> phi(
         this->matrix_free, this->dof_index);


### PR DESCRIPTION
The call was missing in one of the situations. Exception message was also improved.