### PR TITLE
Output advection velocities

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/advection.h
+++ b/applications/sintering/include/pf-applications/sintering/advection.h
@@ -241,6 +241,20 @@ namespace Sintering
       return v_adv;
     }
 
+    Tensor<1, dim, Number>
+    get_translation_velocity_for_grain(const unsigned int index) const
+    {
+      const Number *data = grain_data(index);
+
+      const Number                 volume(*data++);
+      const Tensor<1, dim, Number> force(make_array_view(data, data + dim));
+
+      // Translational velocity
+      const auto vt = mt * force / volume;
+
+      return vt;
+    }
+
     std::vector<unsigned int> &
     get_index_ptr()
     {

--- a/applications/sintering/include/pf-applications/sintering/driver.h
+++ b/applications/sintering/include/pf-applications/sintering/driver.h
@@ -2802,6 +2802,13 @@ namespace Sintering
           if (params.output_data.fields.count("mf_indices"))
             MyMatrixFreeTools::add_mf_indices_vector(matrix_free, data_out);
 
+          if (params.output_data.fields.count("trans"))
+            Postprocessors::add_translation_velocities_vectors(
+              matrix_free,
+              advection_mechanism,
+              sintering_operator.get_data().n_grains(),
+              data_out);
+
           data_out.build_patches(mapping, this->fe->tensor_degree());
 
           const std::string output = params.output_data.vtk_path + "/" + label +

--- a/applications/sintering/include/pf-applications/sintering/operator_sintering_generic.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_sintering_generic.h
@@ -655,6 +655,24 @@ namespace Sintering
         }
     }
 
+    template <int n_comp, int n_grains>
+    void
+    do_add_data_vectors_kernel(DataOut<dim> &               data_out,
+                               const BlockVectorType &      vec,
+                               const std::set<std::string> &fields_list) const
+    {
+      // Output from the parent
+      SinteringOperatorBase<
+        dim,
+        Number,
+        VectorizedArrayType,
+        SinteringOperatorGeneric<dim, Number, VectorizedArrayType>>::
+        template do_add_data_vectors_kernel<n_comp, n_grains>(data_out,
+                                                              vec,
+                                                              fields_list);
+
+    }
+
   private:
     template <int n_comp,
               int n_grains,

--- a/applications/sintering/include/pf-applications/sintering/parameters.h
+++ b/applications/sintering/include/pf-applications/sintering/parameters.h
@@ -240,7 +240,9 @@ namespace Sintering
                                     "flux",
                                     "energy",
                                     "subdomain",
-                                    "mf_indices"};
+                                    "mf_indices",
+                                    "vel",
+                                    "trans"};
     bool                  mesh_overhead_estimate = false;
     bool                  only_control_boxes     = false;
 
@@ -846,7 +848,7 @@ namespace Sintering
                         output_data.vtk_path,
                         "Path to write VTK files.");
       const std::string output_fields_options =
-        "CH|AC|displ|bnds|gb|d2f|M|dM|kappa|L|energy|flux|subdomain|mf_indices";
+        "CH|AC|displ|bnds|gb|d2f|M|dM|kappa|L|energy|flux|subdomain|mf_indices|vel|trans";
       prm.add_parameter("Fields",
                         output_data.fields,
                         "Fields to output.",

--- a/applications/sintering/include/pf-applications/sintering/postprocessors.h
+++ b/applications/sintering/include/pf-applications/sintering/postprocessors.h
@@ -2618,7 +2618,7 @@ namespace Sintering
         &                advection_mechanism,
       const unsigned int n_order_parameters,
       DataOut<dim> &     data_out,
-      const std::string  prefix = "vel_trans")
+      const std::string  prefix = "trans")
     {
       std::vector<Vector<double>> velocities;
 

--- a/applications/sintering/include/pf-applications/sintering/postprocessors.h
+++ b/applications/sintering/include/pf-applications/sintering/postprocessors.h
@@ -2627,6 +2627,8 @@ namespace Sintering
           velocities.emplace_back(
             matrix_free.get_dof_handler().get_triangulation().n_active_cells());
 
+      Point<dim, VectorizedArrayType> dummy(0.0);
+
       for (unsigned int cell = 0; cell < matrix_free.n_cell_batches(); ++cell)
         {
           advection_mechanism.reinit(cell);
@@ -2635,8 +2637,7 @@ namespace Sintering
             {
               if (advection_mechanism.has_velocity(ig))
                 {
-                  const auto vt =
-                    advection_mechanism.get_translation_velocity(ig);
+                  const auto vt = advection_mechanism.get_velocity(ig, dummy);
 
                   for (unsigned int ilane = 0;
                        ilane <

--- a/applications/sintering/include/pf-applications/sintering/postprocessors.h
+++ b/applications/sintering/include/pf-applications/sintering/postprocessors.h
@@ -2541,10 +2541,15 @@ namespace Sintering
         (moment_s<dim, VectorizedArrayType> == 1) ?
           std::vector({"t"}) :
           std::vector({"tx", "ty", "tz"});
+      const std::vector labels_velocities{"vx", "vy", "vz"};
 
       const auto dummy =
         create_array<1 + dim + moment_s<dim, VectorizedArrayType>>(
           std::numeric_limits<double>::quiet_NaN());
+
+      Tensor<1, dim, Number> dummy_velocities;
+      for (unsigned int d = 0; d < dim; ++d)
+        dummy_velocities[d] = std::numeric_limits<double>::quiet_NaN();
 
       for (const auto &[grain_id, grain] : grain_tracker->get_grains())
         {
@@ -2580,6 +2585,17 @@ namespace Sintering
               for (unsigned int d = 0; d < moment_s<dim, VectorizedArrayType>;
                    ++d)
                 table.add_value(labels_torques[d], *data++);
+
+              // Output translation velocities
+              const Tensor<1, dim, Number> vt =
+                (!advection_mechanism.get_grains_data().empty() &&
+                 grain.n_segments() == 1) ?
+                  advection_mechanism.get_translation_velocity_for_grain(
+                    grain_tracker->get_grain_segment_index(grain_id, 0)) :
+                  dummy_velocities;
+
+              for (unsigned int d = 0; d < dim; ++d)
+                table.add_value(labels_velocities[d], vt[d]);
             }
         }
 


### PR DESCRIPTION
Two ways of the output: from the operator (builds a continuous velocity field) and cell-wise, based on the data contained inside grain tracker.