### PR TITLE
Smooth grain boundary filter for the Wang sintering forces

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/driver.h
+++ b/applications/sintering/include/pf-applications/sintering/driver.h
@@ -944,6 +944,7 @@ namespace Sintering
         params.advection_data.k,
         params.advection_data.cgb,
         params.advection_data.ceq,
+        params.advection_data.smoothening,
         matrix_free,
         constraints,
         sintering_data,

--- a/applications/sintering/include/pf-applications/sintering/parameters.h
+++ b/applications/sintering/include/pf-applications/sintering/parameters.h
@@ -172,11 +172,12 @@ namespace Sintering
   {
     bool enable = false;
 
-    double k   = 100.;
-    double mt  = 1.;
-    double mr  = 1.;
-    double cgb = -1;
-    double ceq = 1.;
+    double k           = 100.;
+    double mt          = 1.;
+    double mr          = 1.;
+    double cgb         = -1;
+    double ceq         = 1.;
+    double smoothening = 0.;
 
     bool check_courant = true;
   };
@@ -730,6 +731,10 @@ namespace Sintering
       prm.add_parameter("Ceq",
                         advection_data.ceq,
                         "Grain boundary equilibrium concentration.");
+      prm.add_parameter(
+        "Smoothening",
+        advection_data.smoothening,
+        "Heaviside smoothening, recommended range 50...5000, 0 = disabled (default).");
       prm.add_parameter("CheckCourant",
                         advection_data.check_courant,
                         "Check Courant condition at the end of the timestep");

--- a/tests/include/sintering_model.h
+++ b/tests/include/sintering_model.h
@@ -183,7 +183,7 @@ namespace Test
       dts[0] = 1e-5;
       sintering_data.time_data.set_all_dt(dts);
 
-      const double k           = 100;
+      const double k           = 25;
       const double cgb         = -1;
       const double ceq         = 1.0;
       const double smoothening = 0;

--- a/tests/include/sintering_model.h
+++ b/tests/include/sintering_model.h
@@ -183,15 +183,17 @@ namespace Test
       dts[0] = 1e-5;
       sintering_data.time_data.set_all_dt(dts);
 
-      double k   = 100;
-      double cgb = -1;
-      double ceq = 1.0;
+      const double k           = 100;
+      const double cgb         = -1;
+      const double ceq         = 1.0;
+      const double smoothening = 0;
 
       advection_operator =
         std::make_unique<AdvectionOperator<dim, Number, VectorizedArrayType>>(
           k,
           cgb,
           ceq,
+          smoothening,
           matrix_free,
           constraints,
           sintering_data,


### PR DESCRIPTION
I observed that the initial discontinuous definition of the grain boundary filter 
![image](https://github.com/hpsint/hpsint/assets/8836201/00387dba-916f-4e0c-9558-a38c96194567)
oftern leads to issues with the nonlinear solver. So I decided to introduce a smoothened function like this:
![image](https://github.com/hpsint/hpsint/assets/8836201/68d7d547-a930-4ffe-8da7-a008803b0934)

The functions look like this ($s_{gb}=0.14$):
![image](https://github.com/hpsint/hpsint/assets/8836201/f441ef70-7813-4788-b2e6-d377932c2278)

The influence on the accuracy for a simple 2 particles test:
![image](https://github.com/hpsint/hpsint/assets/8836201/3a21676c-10be-4340-a5e9-d182d6eee3fa)

For a more comples test of 8 particles in a chain one can see the benefit of the new continuous definition. The default one start exhibiting numerical problems at around $t=75$ and then collapses at $t=120$.
![image](https://github.com/hpsint/hpsint/assets/8836201/2e7cc070-b4f4-4cef-824c-84305fe9979e)

