### PR TITLE
Use cgb = 0 to disable normalization (less confusing)

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/operator_advection.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_advection.h
@@ -394,7 +394,7 @@ namespace Sintering
                           auto etai_etaj = eta_i * eta_j;
 
                           // Normalize or not
-                          if (cgb >= 0)
+                          if (cgb > 0)
                             {
                               if (smoothening > 0)
                                 etai_etaj =

--- a/applications/sintering/include/pf-applications/sintering/parameters.h
+++ b/applications/sintering/include/pf-applications/sintering/parameters.h
@@ -175,7 +175,7 @@ namespace Sintering
     double k           = 100.;
     double mt          = 1.;
     double mr          = 1.;
-    double cgb         = -1;
+    double cgb         = 0.;
     double ceq         = 1.;
     double smoothening = 0.;
 

--- a/tests/include/sintering_model.h
+++ b/tests/include/sintering_model.h
@@ -184,7 +184,7 @@ namespace Test
       sintering_data.time_data.set_all_dt(dts);
 
       const double k           = 25;
-      const double cgb         = -1;
+      const double cgb         = 0;
       const double ceq         = 1.0;
       const double smoothening = 0;
 


### PR DESCRIPTION
The value `-1` has been always confusing me. In fact, `cgb = 0` already means that there is no normalization should be applied.