### PR TITLE
Obtain necks from the VTK files for the 2 particles systems

### DIFF
--- a/applications/sintering/scripts/paraview_2particles.py
+++ b/applications/sintering/scripts/paraview_2particles.py
@@ -1,0 +1,123 @@
+from vtk import vtkXMLUnstructuredGridReader
+from functools import reduce
+import glob
+import re
+import numpy as np
+import argparse
+
+from paraview.simple import *
+
+# Build measurement line
+def build_line(reader, axis):
+    [x_min, x_max, y_min, y_max, z_min, z_max] = reader.GetDataInformation().GetBounds()
+
+    # Default values
+    x_start = (x_max + x_min) / 2
+    y_start = (y_max + y_min) / 2
+    z_start = (z_max + z_min) / 2
+    x_end = x_start
+    y_end = y_start
+    z_end = z_start
+
+    if axis == "x":
+        x_start = x_min
+        x_end = x_max
+        length = x_max - x_min
+    elif axis == "y":
+        y_start = y_min
+        y_end = y_max
+        length = y_max - y_min
+    elif axis == "z":
+        z_start = z_min
+        z_end = z_max
+        length = z_max - z_min
+
+    line = PlotOverLine(reader)
+    line.Point1 = [x_start, y_start, z_start]
+    line.Point2 = [x_end, y_end, z_end]
+    line.Resolution = args.resolution
+    line.UpdatePipeline()
+
+    return [line, length]
+
+# Measure certain value along the line
+def measure_over_line(pline, quantity, threshold, length):
+    nbp = pline.GetDataInformation().GetNumberOfPoints()
+    size_step = length/nbp
+
+    active_points_count = 0
+
+    fullData = servermanager.Fetch(pline)
+    vals = fullData.GetPointData().GetScalars(quantity)
+
+    for jpoint in range(0, nbp):
+        q_val = vals.GetValue(jpoint)
+        if (q_val > threshold):
+            active_points_count += 1
+
+    magnitude = size_step * active_points_count
+
+    return magnitude
+
+# Script arguments
+parser = argparse.ArgumentParser(description='Process shrinkage data')
+parser.add_argument("-m", "--mask", type=str, help="File mask", required=True)
+parser.add_argument("-o", "--output", type=str, help="Output csv file", required=False, default="")
+parser.add_argument("-r", "--resolution", type=int, help="Number of points for the line filters", required=False, default=10000)
+parser.add_argument("-t", "--threshold", type=float, help="Minimum value for the quantity", required=False, default=0.5)
+parser.add_argument("-q", "--quantity", type=str, help="Quantity data name to analyze", required=False, default="c")
+parser.add_argument("-a", "--alignment", type=str, help="Axis along which the assembly is aligned", required=False, default="x")
+parser.add_argument("-d", "--direction", type=str, help="Axis along which the neck is measured", required=False, default="y")
+
+args = parser.parse_args()
+
+# Get vtk files according to the mask and sort it by number
+vtk_files_list = glob.glob(args.mask)
+vtk_files_list.sort(key=lambda f: int(re.sub('\D', '', f)))
+
+# Build reader
+#reader = vtkXMLUnstructuredGridReader()
+
+# CSV data
+csv_header = ["t", "neck_diameter", "neck_growth", "length", "shrinkage"]
+n_rows = len(vtk_files_list)
+n_cols = len(csv_header)
+csv_data = np.zeros(shape=(n_rows, n_cols))
+
+# Get initial assembly length and particle diameter
+reader = XMLUnstructuredGridReader(FileName=vtk_files_list[0])
+reader.UpdatePipeline()
+
+[line_length, domain_length] = build_line(reader, args.alignment)
+length0 = measure_over_line(line_length, args.quantity, args.threshold, domain_length)
+
+diameter0 = length0 / 2
+
+for idx, vtk_file in enumerate(vtk_files_list):
+
+    print("Parsing file {} ({}/{})".format(vtk_file, idx + 1, n_rows))
+
+    reader = XMLUnstructuredGridReader(FileName=vtk_file)
+    reader.UpdatePipeline()
+
+    # Measurement lines
+    [line_length, domain_length] = build_line(reader, args.alignment)
+    [line_neck, domain_width] = build_line(reader, args.direction)
+
+    neck_diameter = measure_over_line(line_neck, args.quantity, args.threshold, domain_width)
+    neck_growth = neck_diameter / diameter0
+
+    length = measure_over_line(line_length, args.quantity, args.threshold, domain_length)
+    shrinkage = (length0 - length) / length0
+
+    csv_data[idx, 0] = 0
+    csv_data[idx, 1] = neck_diameter
+    csv_data[idx, 2] = neck_growth
+    csv_data[idx, 3] = length
+    csv_data[idx, 4] = shrinkage
+
+# Save to csv
+if len(args.output) > 0:
+    np.savetxt(args.output, csv_data, header=','.join(csv_header), comments='', delimiter=',')
+
+print(csv_data)

--- a/applications/sintering/scripts/plot_data.py
+++ b/applications/sintering/scripts/plot_data.py
@@ -54,6 +54,8 @@ parser.add_argument("-s", "--skip-first", dest='skip_first', required=False, hel
 parser.add_argument("-g", "--single-legend", dest='single_legend', required=False, help="Use single legend", action="store_true", default=False)
 parser.add_argument("-b", "--labels", dest='labels', required=False, nargs='+', help="Customized labels", default=None)
 parser.add_argument("-r", "--delimiter", dest='delimiter', required=False, help="Input file delimiter", default=None)
+parser.add_argument("--normalize-xaxis", dest='normalize_xaxis', required=False, help="Normalize x-axis", action="store_true", default=False)
+parser.add_argument("--normalize-yaxis", dest='normalize_yaxis', required=False, help="Normalize y-axis", action="store_true", default=False)
 
 args = parser.parse_args()
 
@@ -134,6 +136,8 @@ for i in range(n_fields):
             mask[0] = False
         
         x = cdata[args.xaxis][mask]
+        if args.normalize_xaxis and max(x):
+            x /= max(x)
 
         # Maybe it is a formula - we will try to interpret it, its safety is implied
         y_label = field
@@ -163,6 +167,9 @@ for i in range(n_fields):
 
         x_lims[0] = min(x_lims[0], x[0])
         x_lims[1] = max(x_lims[1], x[-1])
+
+        if args.normalize_yaxis and max(y):
+            y /= max(y)
 
         a.plot(x, y, color=clr, linestyle='-', linewidth=2, label=lbl, marker=mrk, markevery=n_files)
 


### PR DESCRIPTION
This script extracts neck growth and shrinkage from the VTK data. Though it can be applied to any particles assemblies, the measurement of the neck size is tuned for the case of a 2 particles system.

The idea appeared when I tried to analyze if the compressive Wang forces in combination with the diffusion properties deliver the same kinematics for systems of different scale. To this end, I run the 2 particles case in 2D with different particles radii: 10 and 20. Of course, the system with larger particles will sinter much longer, but the idea was to check if the sitenring forces, the neck growth and the shrinkage rate are qualitatively comparable: the curves should align if the time is normalized. As one can see, this is indeed the case. For the smaller particles case I used $t_\text{end}=200$ and for the larger $t_\text{end}=2000$. Without time normalization making such a comparison is a bit difficult, as can be seen from plots.

One should also note, that in order to compare shrinkage, we need to rely on the data extracted from the grain tracker. This is due to the fact that the shape of particles for these 2 simulation cases can be quite different at the end of the simulations due to the surface diffusion effects and this influences the results as can be seen in the last table below.

The cases to run:
```
./applications/sintering/sintering-2D-generic-scalar --hypercube 10 2 1 ~/work/pf-applications/settings/debug/2d_generic_advection_arrays.json --TimeIntegration.TimeEnd=200
./applications/sintering/sintering-2D-generic-scalar --hypercube 20 2 1 ~/work/pf-applications/settings/debug/2d_generic_advection_arrays.json
```

### Neck grwoth from VTK
| non-normalized time | normalized time |
| ------------- | ------------- |
| ![neck_growth_from_vtk_data](https://github.com/hpsint/hpsint/assets/8836201/bd2c1bdd-0965-464d-b501-fffb67a69832) | ![neck_growth_from_vtk_data_normalized](https://github.com/hpsint/hpsint/assets/8836201/186ef175-5206-4ed8-b9b5-ad22d87436be) |

### Shrinakge from GT data
| non-normalized time | normalized time |
| ------------- | ------------- |
| ![shrinkage_from_gt_data](https://github.com/hpsint/hpsint/assets/8836201/264b130a-024e-4e19-8515-aea583f90294) | ![shrinkage_from_gt_data_normalized](https://github.com/hpsint/hpsint/assets/8836201/48c67309-8503-4d78-b1b1-e33d90c360d6) |

### Shrinakge from generic solution data
| non-normalized time | normalized time |
| ------------- | ------------- |
| ![shrinkage_from_generic_solution_data](https://github.com/hpsint/hpsint/assets/8836201/971a4ca2-ff01-40e1-a693-d7f04e662b53) | ![shrinkage_from_generic_solution_data_normalized](https://github.com/hpsint/hpsint/assets/8836201/c211db11-020f-4bb1-b4e4-99453cb9b86f) |

#### Logs and settings file
[run_10.log](https://github.com/hpsint/hpsint/files/14424001/run_10.log)
[run_20.log](https://github.com/hpsint/hpsint/files/14424002/run_20.log)
[2d_generic_advection_arrays.json.txt](https://github.com/hpsint/hpsint/files/14423999/2d_generic_advection_arrays.json.txt)
