### PR TITLE
Compute control volume

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/driver.h
+++ b/applications/sintering/include/pf-applications/sintering/driver.h
@@ -2912,10 +2912,9 @@ namespace Sintering
         if (params.output_data.control_boxes.empty())
           return name;
         else if (params.output_data.only_control_boxes)
-          return name + "_box" + std::to_string(index);
+          return name + "_" + std::to_string(index);
         else
-          return (index == 0) ? name :
-                                (name + "_box" + std::to_string(index - 1));
+          return (index == 0) ? name : (name + "_" + std::to_string(index - 1));
       };
 
       if (params.output_data.table)
@@ -2999,7 +2998,7 @@ namespace Sintering
                   const auto box_volume =
                     box_filters[i]->get_bounding_box().volume();
 
-                  table.add_value(generate_name("cntrl_box", i), box_volume);
+                  table.add_value(generate_name("control_box", i), box_volume);
                 }
 
               if (params.output_data.iso_surf_area)

--- a/applications/sintering/include/pf-applications/sintering/parameters.h
+++ b/applications/sintering/include/pf-applications/sintering/parameters.h
@@ -866,7 +866,7 @@ namespace Sintering
                         output_data.only_control_boxes,
                         "Output only for control boxes.");
       const std::string domain_integrals_options =
-        "gb_area|solid_vol|surf_area|avg_grain_size|surf_area_nrm|free_energy|bulk_energy|interface_energy|order_params";
+        "gb_area|solid_vol|surf_area|avg_grain_size|surf_area_nrm|free_energy|bulk_energy|interface_energy|order_params|control_vol";
       prm.add_parameter("DomainIntegrals",
                         output_data.domain_integrals,
                         "Domain integral quantities.",

--- a/applications/sintering/include/pf-applications/sintering/postprocessors.h
+++ b/applications/sintering/include/pf-applications/sintering/postprocessors.h
@@ -2487,6 +2487,16 @@ namespace Sintering
                     return i < n_grains ? value[2 + i] : 0.;
                   });
               }
+          else if (qty == "control_vol")
+            q_evaluators.emplace_back(
+              [](const VectorizedArrayType *                value,
+                 const Tensor<1, dim, VectorizedArrayType> *gradient,
+                 const unsigned int                         n_grains) {
+                (void)gradient;
+                (void)n_grains;
+
+                return VectorizedArrayType(1.);
+              });
           else
             AssertThrow(false,
                         ExcMessage("Invalid domain integral provided: " + qty));


### PR DESCRIPTION
The algorithm that computes quantities within control boxes may generate real boxes that look like this (the edges or corners in 2D are slightly cut):
![Capture](https://github.com/hpsint/hpsint/assets/8836201/a4a2f19c-3861-4cbb-8b54-275666e0802a)
The real control volume within which the quantities are computed is always less than the initially defined cubic box. This leads to sometimes awkward plots like this:
![Figure_1](https://github.com/hpsint/hpsint/assets/8836201/de1fa83d-b5cc-4dfd-bc99-23ec566bfd15)

The decrease of the relative density within the control box looks odd. But this happens exactly since after a yet another remeshing step the mesh accidentally adjusted itself such that those "cuts" has become bigger. The issue is particularly visible on corase meshes. So the way to overcome this behavior is to use the real `control_vol` quantity that is computed as in this PR instead of `control_box`.