### PR TITLE
Output naive linear strain

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/parameters.h
+++ b/applications/sintering/include/pf-applications/sintering/parameters.h
@@ -866,7 +866,7 @@ namespace Sintering
                         output_data.only_control_boxes,
                         "Output only for control boxes.");
       const std::string domain_integrals_options =
-        "gb_area|solid_vol|surf_area|avg_grain_size|surf_area_nrm|free_energy|bulk_energy|interface_energy|order_params|control_vol";
+        "gb_area|solid_vol|surf_area|avg_grain_size|surf_area_nrm|free_energy|bulk_energy|interface_energy|order_params|control_vol|strain_lin";
       prm.add_parameter("DomainIntegrals",
                         output_data.domain_integrals,
                         "Domain integral quantities.",

--- a/applications/structural/include/pf-applications/structural/tools.h
+++ b/applications/structural/include/pf-applications/structural/tools.h
@@ -9,6 +9,30 @@ namespace Structural
   template <int dim>
   constexpr unsigned int voigt_size = dim *((dim + 1) / 2.);
 
+  namespace internal
+  {
+    template <int dim>
+    struct VoigtIndices
+    {};
+
+    template <>
+    struct VoigtIndices<2>
+    {
+      static constexpr std::array<const char *, voigt_size<2>> indices = {
+        {"eps_xx", "eps_yy", "tau_xy"}};
+    };
+
+    template <>
+    struct VoigtIndices<3>
+    {
+      static constexpr std::array<const char *, voigt_size<3>> indices = {
+        {"eps_xx", "eps_yy", "eps_zz", "tau_xy", "tau_yz", "tau_xz"}};
+    };
+  } // namespace internal
+
+  template <int dim>
+  inline constexpr auto voigt_indices = internal::VoigtIndices<dim>::indices;
+
   template <int dim, typename Number>
   Tensor<1, voigt_size<dim>, Number>
   apply_l(Tensor<2, dim, Number> gradient_in)


### PR DESCRIPTION
Output linearized strain for the current timestep, it is quite naive and can be used mainly for control plausibility of the results.