### PR TITLE
Build tex clouds

### DIFF
--- a/applications/sintering/scripts/build_tex_packings.py
+++ b/applications/sintering/scripts/build_tex_packings.py
@@ -174,9 +174,9 @@ with open(ofname, 'w') as f:
                         if show_labels:
                             f.write("\\node[anchor=center] at (%f,%f) {%s\color{%s} %d};\n" % (c[0] + xs, c[1] + ys, args.font_size, color, lbl))
                         else:
-                            f.write("\\fill [color=%s] (%f, %f) circle (%f);\n" % (color, c[0] + args.shift, c[1], center_tick_radius_normalized))
+                            f.write("\\fill [color=%s] (%f, %f) circle (%f);\n" % (color, c[0] + xs, c[1] + ys, center_tick_radius_normalized))
                     elif not show_labels:
-                        f.write("\\fill [color=%s] (%f, %f) circle (%f);\n" % (args.color_text, c[0] + args.shift, c[1], center_tick_radius_normalized))
+                        f.write("\\fill [color=%s] (%f, %f) circle (%f);\n" % (args.color_text, c[0] + xs, c[1] + ys, center_tick_radius_normalized))
 
                 f.write("\n")
 

--- a/applications/sintering/scripts/build_tex_packings.py
+++ b/applications/sintering/scripts/build_tex_packings.py
@@ -1,0 +1,183 @@
+import os
+import numpy as np
+import argparse
+import library
+from scipy.spatial import ConvexHull
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-f", "--files", dest="files", required=True, nargs='+', help="Files to process, can be mask")
+parser.add_argument("-e", "--headers", dest='headers', required=False, nargs='+', help="Headers")
+parser.add_argument("-o", "--output", dest='output', required=False, help="Destination path to output tex file", type=str, default=None)
+parser.add_argument("-d", "--dim", dest='dim', required=False, help="Dimension", type=int, default=2)
+parser.add_argument("-x", "--x-shift", dest='xshift', required=False, help="x-axis shift", type=float, default=0.0)
+parser.add_argument("-y", "--y-shift", dest='yshift', required=False, help="y-axis shift", type=float, default=0.0)
+parser.add_argument("-u", "--x-interval", dest='xinterval', required=False, help="x-axis interval", type=float, default=0.05)
+parser.add_argument("-v", "--y-interval", dest='yinterval', required=False, help="y-axis interval", type=float, default=0.05)
+parser.add_argument("-w", "--row-limit", dest='row_limit', required=False, help="Maximum number of pictures per row", type=int, default=3)
+parser.add_argument("-s", "--scale", dest='scale', required=False, help="Scale", type=float, default=3.0)
+parser.add_argument("-a", "--coarsening", dest='coarsening', required=False, help="Coarsening - picks every n-th point", type=int, default=1)
+parser.add_argument("-p", "--order-params", dest='order_params', required=False, nargs='+', help="Pick only selected order parameters", type=int, default=None)
+
+# Styling settings
+parser.add_argument("-c", "--center-tick-ratio", dest='center_tick_ratio', required=False, help="Center tick ratio", type=float, default=0.2)
+parser.add_argument("-i", "--circle-opacity", dest='circle_opacity', required=False, help="Circle fill opacity for 0D", type=float, default=0.6)
+parser.add_argument("-r", "--color-text", dest='color_text', required=False, help="Color text", type=str, default='white')
+parser.add_argument("-n", "--font-size", dest='font_size', required=False, help="Font size", type=str, default='\\scriptsize')
+
+parser.add_argument("-g", "--show-topology", dest='show_topology', required=False, help="Show grain topology", action="store_true", default=False)
+parser.add_argument("-m", "--show-simplified", dest='show_simplified', required=False, help="Show simplified representation", action="store_true", default=False)
+
+group = parser.add_mutually_exclusive_group(required=False)
+group.add_argument("--label-grain-ids", dest='label_grain_ids', required=False, help="Show grain ids as labels", action="store_true", default=False)
+group.add_argument("--label-order-params", dest='label_order_params', required=False, help="Show order params as labels", action="store_true", default=False)
+
+args = parser.parse_args()
+
+show_labels = args.label_grain_ids or args.label_order_params
+
+def build_grain(pts):
+    if args.dim == 2:
+        center = pts.mean(0)
+        angle = np.arctan2(*(pts - center).T[::-1])
+        index = np.argsort(angle)
+    else:
+        hull = ConvexHull(pts)
+        index = hull.vertices
+    
+    return index[0::args.coarsening]
+
+# Get all files to process
+files_list = library.get_solutions(args.files)
+
+if args.output:
+    ofname = args.output
+else:
+    fname_without_ext = os.path.splitext(args.files)[0]
+    ofname = fname_without_ext + ".tex"
+
+if not files_list:
+    raise Exception("The files list is empty, nothing to process")
+
+# Deal with block headers
+#if type(files) is not list:
+if len(files_list) == 1:
+    fname_without_ext = os.path.splitext(os.path.basename(files_list[0]))[0]
+    headers = [fname_without_ext]
+else:
+    headers = library.generate_short_labels(files_list)
+
+if args.headers:
+    for i in range(min(len(headers), len(args.headers))):
+        headers[i] = args.headers[min(i, len(args.headers) - 1)]
+
+# Get color scheme based on the order params number
+n_op = 0
+for file in files_list:
+    src_file = open(file, 'rb')
+    src_file.readline() # skip first line
+    data = src_file.readline()
+    n_op = max(n_op, int(data))
+
+colors = library.get_hex_colors(n_op)
+
+with open(ofname, 'w') as f:
+
+    for ic, clr in enumerate(colors):
+        rgb = library.hex_to_rgb(colors[ic])
+        f.write("\\definecolor{clr%d}{RGB}{%d,%d,%d}\n" % (ic, rgb[0], rgb[1], rgb[2]))
+
+    for j, file in enumerate(files_list):
+    
+        src_file = open(file, 'rb')
+        data = src_file.readlines()
+        data = [d.decode('ascii') for d in data]
+        data = [d.replace(" \n", "").replace("\n", "") for d in data]
+
+        n_grains    = int(data[0])
+        n_op        = int(data[1])
+        grain_to_op = [int(i) for i in data[2].split()]
+        point0      = [float(i) for i in data[3].split()]
+        point1      = [float(i) for i in data[4].split()]
+
+        properties = [float(i) for i in data[5].split()]
+        centers = [[float(i) for i in properties[(g*(args.dim + 1)) : (g*(args.dim + 1) + args.dim)]] for g in range(0, n_grains)]
+        radii = [properties[g*(args.dim + 1) + args.dim] for g in range(0, n_grains)]
+
+        points = [[float(i) for i in data[6 + g].split()] for g in range(0, n_grains)]
+        points = [np.array([[p[g*args.dim + d] for d in range(0, args.dim)] for g in range(0, int(len(p)/args.dim))]) for p in points]
+
+        width = point1[0] - point0[0]
+        height = point1[1] - point0[1]
+
+        normalized_width = 1.
+        normalized_height = height/width
+
+        jcol = j % args.row_limit
+        jrow = j // args.row_limit
+
+        xs = args.xshift + jcol*normalized_width + jcol*args.xinterval
+        ys = args.yshift - jrow*normalized_height - jrow*args.yinterval
+
+        if jcol == 0:
+            f.write("\n")
+
+        def normalize_point(p):
+            point = [0] * args.dim
+
+            for d in range(0, args.dim):
+                point[d] = (p[d] - point0[0]) / width
+            
+            return point
+
+        def normalize_radius(r):
+            return r / width
+
+        center_tick_radius_normalized = args.center_tick_ratio * normalize_radius(min(radii))
+        
+        f.write("\\begin{tikzpicture}[scale=%f]\n" % args.scale)
+
+        f.write("\\draw [] (%f,%f) rectangle (%f,%f);\n" % (xs, ys, xs + normalized_width, ys + normalized_height))
+        f.write("\n")
+
+        f.write("\\node[] at (%f,%f) {%s %s};\n" % (0.5 + xs, normalized_height + 0.05 + ys, args.font_size, library.tex_escape(headers[j])))
+
+        for g in range(0, n_grains):
+            if len(points[g]) > 0 and (args.order_params is None or grain_to_op[g] in args.order_params):
+                indices = build_grain(points[g])
+
+                color = "clr{}".format(grain_to_op[g])
+
+                lbl = None
+                if args.label_grain_ids:
+                    lbl = g
+                if args.label_order_params:
+                    lbl = grain_to_op[g]
+
+                if args.show_topology:
+                    f.write("\\draw [fill=%s]\n" % color)
+                    for p in points[g][indices]:
+                        pp = normalize_point(p)
+
+                        f.write("(%f, %f) --\n" % (pp[0] + xs, pp[1] + ys))
+                    f.write("cycle;\n")
+
+                    if show_labels:
+                        c = normalize_point(centers[g])
+                        f.write("\\node[anchor=center] at (%f,%f) {%s\color{%s} %d};\n" % (c[0] + xs, c[1] + ys, args.font_size, args.color_text, lbl))
+
+                if args.show_simplified:
+                    c = normalize_point(centers[g])
+                    r = normalize_radius(radii[g])
+                    f.write("\\draw[dashed, color=%s, fill=%s!10!white, fill opacity=%f] (%f,%f) circle (%f);\n" % (color, color, args.circle_opacity, c[0] + xs, c[1] + ys, r))
+
+                    if not args.show_topology:
+                        if show_labels:
+                            f.write("\\node[anchor=center] at (%f,%f) {%s\color{%s} %d};\n" % (c[0] + xs, c[1] + ys, args.font_size, color, lbl))
+                        else:
+                            f.write("\\fill [color=%s] (%f, %f) circle (%f);\n" % (color, c[0] + args.shift, c[1], center_tick_radius_normalized))
+                    elif not show_labels:
+                        f.write("\\fill [color=%s] (%f, %f) circle (%f);\n" % (args.color_text, c[0] + args.shift, c[1], center_tick_radius_normalized))
+
+                f.write("\n")
+
+        f.write("\\end{tikzpicture}\n")

--- a/applications/sintering/scripts/build_tex_packings.py
+++ b/applications/sintering/scripts/build_tex_packings.py
@@ -87,6 +87,10 @@ with open(ofname, 'w') as f:
     for ic, clr in enumerate(colors):
         rgb = library.hex_to_rgb(colors[ic])
         f.write("\\definecolor{clr%d}{RGB}{%d,%d,%d}\n" % (ic, rgb[0], rgb[1], rgb[2]))
+    
+    f.write("\n")
+
+    f.write("\\begin{tikzpicture}[scale=%f]\n" % args.scale)
 
     for j, file in enumerate(files_list):
 
@@ -137,8 +141,6 @@ with open(ofname, 'w') as f:
             return r / width
 
         center_tick_radius_normalized = args.center_tick_ratio * normalize_radius(min(radii))
-        
-        f.write("\\begin{tikzpicture}[scale=%f]\n" % args.scale)
 
         f.write("\\draw [] (%f,%f) rectangle (%f,%f);\n" % (xs, ys, xs + normalized_width, ys + normalized_height))
         f.write("\n")
@@ -184,4 +186,4 @@ with open(ofname, 'w') as f:
 
                 f.write("\n")
 
-        f.write("\\end{tikzpicture}\n")
+    f.write("\\end{tikzpicture}\n")

--- a/applications/sintering/scripts/library.py
+++ b/applications/sintering/scripts/library.py
@@ -17,7 +17,7 @@ def hex_to_rgb(chex):
     h = chex.lstrip('#')
     return tuple(int(h[i:i+2], 16) for i in (0, 2, 4))
 
-def get_solutions(files, do_print = True):
+def get_solutions(files, do_print = True, do_sort = True):
 
     if type(files) is not list:
         raise Exception("Variable files={} is not list".format(files))
@@ -25,10 +25,12 @@ def get_solutions(files, do_print = True):
     files_list = []
     for fm in files:
         current_files_list = glob.glob(fm, recursive=True)
-        current_files_list.sort()
+        if do_sort:
+            current_files_list.sort()
         files_list += current_files_list
 
-    files_list = sorted(list(set(files_list)))
+    if do_sort:
+        files_list = sorted(list(set(files_list)))
 
     if do_print:
         print("The complete list of files to process:")

--- a/applications/sintering/scripts/library.py
+++ b/applications/sintering/scripts/library.py
@@ -13,6 +13,10 @@ def get_hex_colors(N):
         hex_out.append('#%02x%02x%02x' % tuple(rgb))
     return hex_out
 
+def hex_to_rgb(chex):
+    h = chex.lstrip('#')
+    return tuple(int(h[i:i+2], 16) for i in (0, 2, 4))
+
 def get_solutions(files, do_print = True):
 
     if type(files) is not list:
@@ -178,3 +182,25 @@ def clean_folder(folder):
                 shutil.rmtree(file_path)
         except Exception as e:
             print('Failed to delete %s. Reason: %s' % (file_path, e))
+
+def tex_escape(text):
+    """
+        :param text: a plain text message
+        :return: the message escaped to appear correctly in LaTeX
+    """
+    conv = {
+        '&': r'\&',
+        '%': r'\%',
+        '$': r'\$',
+        '#': r'\#',
+        '_': r'\_',
+        '{': r'\{',
+        '}': r'\}',
+        '~': r'\textasciitilde{}',
+        '^': r'\^{}',
+        '\\': r'\textbackslash{}',
+        '<': r'\textless{}',
+        '>': r'\textgreater{}',
+    }
+    regex = re.compile('|'.join(re.escape(str(key)) for key in sorted(conv.keys(), key = lambda item: - len(item))))
+    return regex.sub(lambda match: conv[match.group()], text)


### PR DESCRIPTION
This is the generalization of @peterrum's script used for making some nice images in the solver paper. This version allows to create images like this:

### Grains
![image](https://github.com/hpsint/hpsint/assets/8836201/42178bf1-a8c2-496a-89f9-a37eb60cdb44)
```
python build_tex_packings.py -f contour_solution.1.txt contour_solution.23.txt contour_solution.236.txt \ 
-o plot.tex --scale=5 --show-topology --label-order-params --coarsening=5
```
or

### Simplified 0D representation
![image](https://github.com/hpsint/hpsint/assets/8836201/83bc3f67-a420-4fb7-869e-6880e8b7d034)
```
python build_tex_packings.py -f contour_solution.1.txt contour_solution.23.txt contour_solution.236.txt \
-o plot.tex --scale=5 --show-simplified
```
or

### Grains + Simplified 0D representation
![image](https://github.com/hpsint/hpsint/assets/8836201/2bf08641-db4f-4390-a070-4f0f44e1e8fc)
```
python build_tex_packings.py -f contour_solution.1.txt contour_solution.23.txt contour_solution.236.txt \ 
-o plot.tex --scale=5 --show-topology --show-simplified --label-order-params --coarsening=5 --circle-opacity=0.4
```

[contour_solution.1.txt](https://github.com/hpsint/hpsint/files/15096948/contour_solution.1.txt)
[contour_solution.23.txt](https://github.com/hpsint/hpsint/files/15096950/contour_solution.23.txt)
[contour_solution.236.txt](https://github.com/hpsint/hpsint/files/15096952/contour_solution.236.txt)
