### PR TITLE
Fix `current_min_mesh_quality` and `current_max_refinement_depth` on restart

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/driver.h
+++ b/applications/sintering/include/pf-applications/sintering/driver.h
@@ -374,6 +374,9 @@ namespace Sintering
       else
         AssertThrow(false, ExcNotImplemented());
 
+      pcout << "Loading restart data at t = " << t << " (" << restart_path
+            << ")" << std::endl;
+
       // 1) create coarse mesh
       create_grid(initial_mesh, InitialRefine::None);
 
@@ -2639,6 +2642,9 @@ namespace Sintering
                     const std::string prefix =
                       params.restart_data.prefix + "_" +
                       std::to_string(current_restart_count);
+
+                    pcout << "Saving restart data at t = " << t << " ("
+                          << prefix << ")" << std::endl;
 
                     std::vector<const typename VectorType::BlockType *>
                       solution_ptr;

--- a/applications/sintering/include/pf-applications/sintering/driver.h
+++ b/applications/sintering/include/pf-applications/sintering/driver.h
@@ -188,21 +188,18 @@ namespace Sintering
       fe = create_fe(params.approximation_data.fe_degree,
                      params.approximation_data.n_subdivisions);
 
-      geometry_domain_boundaries   = initial_solution->get_domain_boundaries();
-      geometry_r_max               = initial_solution->get_r_max();
-      geometry_interface_width     = initial_solution->get_interface_width();
-      n_global_levels_0            = 0;
-      current_max_refinement_depth = 0;
-      current_min_mesh_quality     = 0;
-      time_last_output             = 0;
-      n_timestep                   = 0;
-      n_timestep_last_amr          = 0;
-      n_timestep_last_gt           = 0;
-      n_linear_iterations          = 0;
-      n_non_linear_iterations      = 0;
-      n_residual_evaluations       = 0;
-      n_failed_tries               = 0;
-      n_failed_linear_iterations   = 0;
+      geometry_domain_boundaries = initial_solution->get_domain_boundaries();
+      geometry_r_max             = initial_solution->get_r_max();
+      geometry_interface_width   = initial_solution->get_interface_width();
+      time_last_output           = 0;
+      n_timestep                 = 0;
+      n_timestep_last_amr        = 0;
+      n_timestep_last_gt         = 0;
+      n_linear_iterations        = 0;
+      n_non_linear_iterations    = 0;
+      n_residual_evaluations     = 0;
+      n_failed_tries             = 0;
+      n_failed_linear_iterations = 0;
       n_failed_non_linear_iterations = 0;
       n_failed_residual_evaluations  = 0;
       max_reached_dt                 = 0.0;
@@ -243,6 +240,13 @@ namespace Sintering
       const unsigned int n_refinements_remaining =
         create_grid(initial_mesh, global_refine);
       n_global_levels_0 = tria.n_global_levels() + n_refinements_remaining;
+
+      // Set the maximum refinement depth
+      current_max_refinement_depth =
+        params.adaptivity_data.max_refinement_depth;
+
+      // Set the minimum mesh quality
+      current_min_mesh_quality = params.adaptivity_data.quality_min;
 
       initialize();
 
@@ -1638,13 +1642,6 @@ namespace Sintering
       VectorType &solution = solution_history.get_current_solution();
 
       bool system_has_changed = true;
-
-      // Set the maximum refinement depth
-      this->current_max_refinement_depth =
-        params.adaptivity_data.max_refinement_depth;
-
-      // Set the minimum mesh quality
-      current_min_mesh_quality = params.adaptivity_data.quality_min;
 
       const auto execute_coarsening_and_refinement =
         [&](const double t,


### PR DESCRIPTION
Previously parameters `current_min_mesh_quality` and `current_max_refinement_depth` were overwritten with the default values when restart is performed.