### PR TITLE
Save/load grains for restarts

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/driver.h
+++ b/applications/sintering/include/pf-applications/sintering/driver.h
@@ -204,8 +204,10 @@ namespace Sintering
       n_failed_residual_evaluations  = 0;
       max_reached_dt                 = 0.0;
       restart_counter                = 0;
-      t                              = 0;
       counters                       = {};
+
+      // Current time
+      t = params.time_integration_data.time_start;
 
       // Initialize timestepping
       const unsigned int time_integration_order =
@@ -2054,9 +2056,10 @@ namespace Sintering
         solution_history.filter(true, false, true).get_all_blocks_raw(), timer);
 
       // initial local refinement
-      if (t == 0.0 && (params.adaptivity_data.refinement_frequency > 0 ||
-                       params.adaptivity_data.quality_control ||
-                       params.geometry_data.global_refinement != "Full"))
+      if (t == params.time_integration_data.time_start &&
+          (params.adaptivity_data.refinement_frequency > 0 ||
+           params.adaptivity_data.quality_control ||
+           params.geometry_data.global_refinement != "Full"))
         {
           // Initialize only the current solution
           const auto solution_ptr =
@@ -2128,7 +2131,8 @@ namespace Sintering
             postproc_operator.add_data_vectors(data_out, postproc_lhs, {});
           };
 
-      if (t == 0.0 && params.output_data.output_time_interval > 0.0)
+      if (t == params.time_integration_data.time_start &&
+          params.output_data.output_time_interval > 0.0)
         output_result(solution,
                       nonlinear_operator,
                       grain_tracker,

--- a/include/pf-applications/grain_tracker/grain.h
+++ b/include/pf-applications/grain_tracker/grain.h
@@ -45,6 +45,8 @@ namespace GrainTracker
       Growing   = 1
     };
 
+    Grain() = default;
+
     Grain(const unsigned int grain_id, const unsigned int order_parameter_id)
       : grain_id(grain_id)
       , order_parameter_id(order_parameter_id)
@@ -222,6 +224,22 @@ namespace GrainTracker
     set_dynamics(const Dynamics new_dynamics)
     {
       dynamics = new_dynamics;
+    }
+
+    /* Grain serialization */
+    template <class Archive>
+    void
+    serialize(Archive &ar, const unsigned int /*version*/)
+    {
+      ar &grain_id;
+      ar &order_parameter_id;
+      ar &old_order_parameter_id;
+      ar &segments;
+      ar &max_radius;
+      ar &distance_to_nearest_neighbor;
+      ar &dynamics;
+      ar &max_value;
+      ar &sum_measure;
     }
 
   private:

--- a/include/pf-applications/grain_tracker/segment.h
+++ b/include/pf-applications/grain_tracker/segment.h
@@ -29,6 +29,8 @@ namespace GrainTracker
   class Segment
   {
   public:
+    Segment() = default;
+
     Segment(const Point<dim> &center_in,
             const double      radius_in,
             const double      measure_in,
@@ -73,6 +75,16 @@ namespace GrainTracker
       const double current_distance = distance_centers - sum_radii;
 
       return current_distance;
+    }
+
+    template <class Archive>
+    void
+    serialize(Archive &ar, const unsigned int /*version*/)
+    {
+      ar &center;
+      ar &radius;
+      ar &measure;
+      ar &max_value;
     }
 
   protected:

--- a/include/pf-applications/grain_tracker/tracker.h
+++ b/include/pf-applications/grain_tracker/tracker.h
@@ -39,7 +39,9 @@
 #include <pf-applications/lac/dynamic_block_vector.h>
 
 #include <functional>
+#include <iterator>
 #include <stack>
+#include <type_traits>
 
 #include "distributed_stitching.h"
 #include "grain.h"
@@ -991,6 +993,25 @@ namespace GrainTracker
     get_grains() const
     {
       return grains;
+    }
+
+    template <typename InputIt,
+              typename = std::enable_if_t<std::is_same_v<
+                typename std::iterator_traits<InputIt>::value_type,
+                Grain<dim>>>>
+    void
+    load_grains(InputIt first, InputIt last)
+    {
+      for (; first != last; ++first)
+        grains.emplace(first->get_grain_id(), *first);
+    }
+
+    template <typename OutputIt>
+    void
+    save_grains(OutputIt output) const
+    {
+      for (const auto &[gid, grain] : grains)
+        *output++ = grain;
     }
 
     // Get active order parameters ids

--- a/include/pf-applications/grain_tracker/tracking.h
+++ b/include/pf-applications/grain_tracker/tracking.h
@@ -21,6 +21,7 @@
 
 #include <functional>
 #include <optional>
+#include <set>
 
 #include "grain.h"
 #include "output.h"

--- a/tests/grains_serialization.cc
+++ b/tests/grains_serialization.cc
@@ -1,0 +1,64 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2023 by the hpsint authors
+//
+// This file is part of the hpsint library.
+//
+// The hpsint library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.MD at
+// the top level directory of hpsint.
+//
+// ---------------------------------------------------------------------
+
+#include <pf-applications/grain_tracker/output.h>
+
+// include input and output archivers
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
+
+// include this header to serialize vectors
+#include <boost/serialization/vector.hpp>
+
+using namespace dealii;
+using namespace GrainTracker;
+
+int
+main()
+{
+  constexpr unsigned int dim = 2;
+
+  std::vector<Grain<dim>> old_grains;
+  std::vector<Grain<dim>> new_grains;
+
+  // A grain with one segment
+  Grain<dim> g1(4, 7, 14);
+  g1.add_segment(Point<dim>(0, 0), 2.0, std::pow(2.0, 2) * M_PI, 1.0);
+  old_grains.push_back(g1);
+
+  // A grain containing 2 segments: small + large
+  Grain<dim> g2(2, 3, 12);
+  g2.add_segment(Point<dim>(2, -9), 1.0, std::pow(1.0, 2) * M_PI, 1.0);
+  g2.add_segment(Point<dim>(8, 0), 3.0, std::pow(3.0, 2) * M_PI, 1.0);
+  old_grains.push_back(g2);
+
+  // Write
+  std::stringstream             sstream;
+  boost::archive::text_oarchive fosb(sstream);
+  fosb << old_grains;
+
+  // Read
+  boost::archive::text_iarchive fisb(sstream);
+  fisb >> new_grains;
+
+  std::cout << "Original grains:" << std::endl;
+  for (const auto &grain : old_grains)
+    print_grain(grain, std::cout);
+  std::cout << std::endl;
+
+  std::cout << "Loaded grains:" << std::endl;
+  for (const auto &grain : new_grains)
+    print_grain(grain, std::cout);
+}

--- a/tests/grains_serialization.output
+++ b/tests/grains_serialization.output
@@ -1,0 +1,13 @@
+Original grains:
+op_index_current = 7 | op_index_old = 14 | segments = 1 | grain_index = 4
+    segment: center = 0 0 | radius = 2 | max_value = 1
+op_index_current = 3 | op_index_old = 12 | segments = 2 | grain_index = 2
+    segment: center = 2 -9 | radius = 1 | max_value = 1
+    segment: center = 8 0 | radius = 3 | max_value = 1
+
+Loaded grains:
+op_index_current = 7 | op_index_old = 14 | segments = 1 | grain_index = 4
+    segment: center = 0 0 | radius = 2 | max_value = 1
+op_index_current = 3 | op_index_old = 12 | segments = 2 | grain_index = 2
+    segment: center = 2 -9 | radius = 1 | max_value = 1
+    segment: center = 8 0 | radius = 3 | max_value = 1


### PR DESCRIPTION
Previously we did not save grain information when saving restart data. This does not break the solution in general, but the grain indices may get lost between the simulation runs, this can be very inconvenient if packing properties have to be analyzed.