### PR TITLE
No gt copy

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/postprocessors.h
+++ b/applications/sintering/include/pf-applications/sintering/postprocessors.h
@@ -468,7 +468,7 @@ namespace Sintering
 
                   for (unsigned int i = old_size; i < cells.size(); ++i)
                     {
-                      if (grain_mapper)
+                      if (grain_mapper && !grain_mapper->get().empty())
                         {
                           const auto particle_id_for_op =
                             grain_mapper->get().get_particle_index(

--- a/include/pf-applications/grain_tracker/mapper.h
+++ b/include/pf-applications/grain_tracker/mapper.h
@@ -38,5 +38,8 @@ namespace GrainTracker
 
     virtual unsigned int
     n_segments() const = 0;
+
+    virtual bool
+    empty() const = 0;
   };
 } // namespace GrainTracker

--- a/include/pf-applications/grain_tracker/tracker.h
+++ b/include/pf-applications/grain_tracker/tracker.h
@@ -1120,6 +1120,12 @@ namespace GrainTracker
       return n_total_segments;
     }
 
+    bool
+    empty() const override
+    {
+      return grains.empty();
+    }
+
     void
     custom_reassignment(
       std::function<void(std::map<unsigned int, Grain<dim>> &)> callback)


### PR DESCRIPTION
Strictly speaking, we do not need to copy grain tracker in those output functions which need to work with it. I refactored those functions a bit in order to get rid of these copies since it is difficult to keep them consistent with the solution vector.