### PR TITLE
Precondition advection terms via nonlinear operator

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/driver.h
+++ b/applications/sintering/include/pf-applications/sintering/driver.h
@@ -1046,16 +1046,19 @@ namespace Sintering
         mg_matrixfrees;
 
       if (transfer)
-        preconditioner = std::make_unique<
-          BlockPreconditioner2<dim, Number, VectorizedArrayType>>(
-          sintering_data,
-          matrix_free,
-          constraints,
-          mg_sintering_data,
-          mg_matrix_free,
-          mg_constraints,
-          transfer,
-          params.preconditioners_data.block_preconditioner_2_data);
+        preconditioner =
+          std::make_unique<BlockPreconditioner2<dim,
+                                                Number,
+                                                VectorizedArrayType,
+                                                NonLinearOperatorTpl>>(
+            sintering_data,
+            matrix_free,
+            constraints,
+            mg_sintering_data,
+            mg_matrix_free,
+            mg_constraints,
+            transfer,
+            params.preconditioners_data.block_preconditioner_2_data);
       else if (params.preconditioners_data.outer_preconditioner ==
                "BlockPreconditioner2")
         {
@@ -1065,25 +1068,31 @@ namespace Sintering
                                                        VectorizedArrayType,
                                                        NonLinearOperator>,
                           NonLinearOperator>)
-            preconditioner = std::make_unique<
-              BlockPreconditioner2<dim, Number, VectorizedArrayType>>(
-              sintering_data,
-              matrix_free,
-              constraints,
-              params.preconditioners_data.block_preconditioner_2_data,
-              advection_mechanism,
-              nonlinear_operator.get_zero_constraints_indices(),
-              params.material_data.mechanics_data.E,
-              params.material_data.mechanics_data.nu,
-              plane_type);
+            preconditioner =
+              std::make_unique<BlockPreconditioner2<dim,
+                                                    Number,
+                                                    VectorizedArrayType,
+                                                    NonLinearOperatorTpl>>(
+                sintering_data,
+                matrix_free,
+                constraints,
+                params.preconditioners_data.block_preconditioner_2_data,
+                advection_mechanism,
+                nonlinear_operator.get_zero_constraints_indices(),
+                params.material_data.mechanics_data.E,
+                params.material_data.mechanics_data.nu,
+                plane_type);
           else
-            preconditioner = std::make_unique<
-              BlockPreconditioner2<dim, Number, VectorizedArrayType>>(
-              sintering_data,
-              matrix_free,
-              constraints,
-              params.preconditioners_data.block_preconditioner_2_data,
-              advection_mechanism);
+            preconditioner =
+              std::make_unique<BlockPreconditioner2<dim,
+                                                    Number,
+                                                    VectorizedArrayType,
+                                                    NonLinearOperatorTpl>>(
+                sintering_data,
+                matrix_free,
+                constraints,
+                params.preconditioners_data.block_preconditioner_2_data,
+                advection_mechanism);
         }
       else
         preconditioner = Preconditioners::create(

--- a/applications/sintering/include/pf-applications/sintering/operator_sintering_data.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_sintering_data.h
@@ -472,4 +472,14 @@ namespace Sintering
 
     double t;
   };
+
+  template <int dim, typename VectorizedArrayType>
+  struct SinteringNonLinearData
+  {
+    decltype(std::declval<const Table<3, VectorizedArrayType>>().operator[](0))
+      const &values;
+    decltype(
+      std::declval<const Table<3, Tensor<1, dim, VectorizedArrayType>>>().
+      operator[](0)) const &gradients;
+  };
 } // namespace Sintering

--- a/applications/sintering/include/pf-applications/sintering/operator_sintering_generic.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_sintering_generic.h
@@ -820,6 +820,31 @@ namespace Sintering
           }
     }
 
+    template <typename FECellIntegratorType>
+    static void
+    precondition_advection_ac(
+      const unsigned int q,
+      const AdvectionVelocityData<dim, Number, VectorizedArrayType>
+        &                                                     advection_data,
+      const SinteringOperatorData<dim, VectorizedArrayType> & sintering_data,
+      const SinteringNonLinearData<dim, VectorizedArrayType> &nonlinear_data,
+      const FECellIntegratorType &                            phi,
+      typename FECellIntegratorType::value_type &             value_result,
+      typename FECellIntegratorType::gradient_type &          gradient_result)
+    {
+      (void)nonlinear_data;
+      (void)value_result;
+
+      for (unsigned int ig = 0; ig < sintering_data.n_grains(); ++ig)
+        if (advection_data.has_velocity(ig))
+          {
+            const auto &velocity_ig =
+              advection_data.get_velocity(ig, phi.quadrature_point(q));
+
+            gradient_result[ig] -= velocity_ig * phi.get_value(q)[0];
+          }
+    }
+
   private:
     template <int n_comp,
               int n_grains,

--- a/applications/sintering/include/pf-applications/sintering/operator_sintering_generic.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_sintering_generic.h
@@ -795,6 +795,31 @@ namespace Sintering
         data_out.add_data_vector(data_vectors[c], names[c]);
     }
 
+    template <typename FECellIntegratorType>
+    static void
+    precondition_advection_ch(
+      const unsigned int q,
+      const AdvectionVelocityData<dim, Number, VectorizedArrayType>
+        &                                                     advection_data,
+      const SinteringOperatorData<dim, VectorizedArrayType> & sintering_data,
+      const SinteringNonLinearData<dim, VectorizedArrayType> &nonlinear_data,
+      const FECellIntegratorType &                            phi,
+      typename FECellIntegratorType::value_type &             value_result,
+      typename FECellIntegratorType::gradient_type &          gradient_result)
+    {
+      (void)nonlinear_data;
+      (void)value_result;
+
+      for (unsigned int ig = 0; ig < sintering_data.n_grains(); ++ig)
+        if (advection_data.has_velocity(ig))
+          {
+            const auto &velocity_ig =
+              advection_data.get_velocity(ig, phi.quadrature_point(q));
+
+            gradient_result[0] -= velocity_ig * phi.get_value(q)[0];
+          }
+    }
+
   private:
     template <int n_comp,
               int n_grains,

--- a/applications/sintering/include/pf-applications/sintering/operator_sintering_generic.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_sintering_generic.h
@@ -845,6 +845,32 @@ namespace Sintering
           }
     }
 
+    template <typename FECellIntegratorType>
+    static void
+    precondition_advection_ac(
+      const unsigned int q,
+      const unsigned int igrain,
+      const AdvectionVelocityData<dim, Number, VectorizedArrayType>
+        &                                                     advection_data,
+      const SinteringOperatorData<dim, VectorizedArrayType> & sintering_data,
+      const SinteringNonLinearData<dim, VectorizedArrayType> &nonlinear_data,
+      const FECellIntegratorType &                            phi,
+      typename FECellIntegratorType::value_type &             value_result,
+      typename FECellIntegratorType::gradient_type &          gradient_result)
+    {
+      (void)sintering_data;
+      (void)nonlinear_data;
+      (void)value_result;
+
+      if (advection_data.has_velocity(igrain))
+        {
+          const auto &velocity_ig =
+            advection_data.get_velocity(igrain, phi.quadrature_point(q));
+
+          gradient_result -= velocity_ig * phi.get_value(q);
+        }
+    }
+
   private:
     template <int n_comp,
               int n_grains,

--- a/applications/sintering/include/pf-applications/sintering/preconditioners.h
+++ b/applications/sintering/include/pf-applications/sintering/preconditioners.h
@@ -1304,7 +1304,7 @@ namespace Sintering
           matrix_free,
           constraints,
           0,
-          "")
+          "helmholtz_op")
       , n_components_(n_components_)
     {}
 

--- a/applications/sintering/include/pf-applications/sintering/preconditioners.h
+++ b/applications/sintering/include/pf-applications/sintering/preconditioners.h
@@ -763,8 +763,6 @@ namespace Sintering
 
                     for (unsigned int q = 0; q < integrator.n_q_points; ++q)
                       {
-                        const auto &val = nonlinear_data.values[q];
-
                         auto value    = integrator.get_value(q);
                         auto gradient = integrator.get_gradient(q);
 


### PR DESCRIPTION
Previous implementation was a bit intrusive. The way how advection terms should be evaluated in preconditioners are , in general, dictated by the nonlinear operator, so it makes sense to delegate this step to `NonLinearOperator` which is now provided via the template parameter. The branches which were responsible for evaluations for the case of the coupeld Wang operator will be similarly integrated later to the coupled operator itself.