### PR TITLE
Update clang-format-lint-action version

### DIFF
--- a/.github/workflows/indentation.yml
+++ b/.github/workflows/indentation.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: DoozyX/clang-format-lint-action@v0.11
+    - uses: DoozyX/clang-format-lint-action@v0.18.2
       with:
         source: '.'
         exclude: ''


### PR DESCRIPTION
I guess this should fix the indentation workflow.