### PR TITLE
Scale ellipsoids

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/postprocessors.h
+++ b/applications/sintering/include/pf-applications/sintering/postprocessors.h
@@ -1558,13 +1558,15 @@ namespace Sintering
                   pores_centers,
                   pores_radii,
                   pores_measures,
-                  pores_max_values] =
+                  pores_max_values,
+                  pores_remotes] =
         GrainTracker::compute_particles_info(dof_handler,
                                              particle_ids,
                                              local_to_global_particle_ids,
                                              offset,
                                              invalid_particle_id);
       (void)pores_max_values;
+      (void)pores_remotes;
 
       const auto comm = dof_handler.get_communicator();
 

--- a/applications/sintering/include/pf-applications/sintering/postprocessors.h
+++ b/applications/sintering/include/pf-applications/sintering/postprocessors.h
@@ -1554,18 +1554,22 @@ namespace Sintering
                                threshold_upper,
                                box_filter);
 
-      const auto [n_pores,
-                  pores_centers,
-                  pores_radii,
-                  pores_measures,
-                  pores_max_values,
-                  pores_remotes] =
+      const auto [n_pores, pores_centers, pores_measures, pores_max_values] =
         GrainTracker::compute_particles_info(dof_handler,
                                              particle_ids,
                                              local_to_global_particle_ids,
                                              offset,
                                              invalid_particle_id);
       (void)pores_max_values;
+
+      const auto [pores_radii, pores_remotes] =
+        GrainTracker::compute_particles_radii(dof_handler,
+                                              particle_ids,
+                                              local_to_global_particle_ids,
+                                              offset,
+                                              pores_centers,
+                                              /*elliptical_grains = */ false,
+                                              invalid_particle_id);
       (void)pores_remotes;
 
       const auto comm = dof_handler.get_communicator();

--- a/include/pf-applications/grain_tracker/distributed_stitching.h
+++ b/include/pf-applications/grain_tracker/distributed_stitching.h
@@ -442,10 +442,8 @@ namespace GrainTracker
   template <int dim, typename VectorIds>
   std::tuple<unsigned int,            // n_particles
              std::vector<Point<dim>>, // particle_centers
-             std::vector<double>,     // particle_radii
              std::vector<double>,     // particle_measures
-             std::vector<double>,     // particle_max_values
-             std::vector<Point<dim>>>
+             std::vector<double>>     // particle_max_values
   compute_particles_info(
     const DoFHandler<dim> &          dof_handler,
     const VectorIds &                particle_ids,
@@ -520,9 +518,32 @@ namespace GrainTracker
         particle_measures[i] = particle_info[i * n_features];
       }
 
+    return std::make_tuple(n_particles,
+                           std::move(particle_centers),
+                           std::move(particle_measures),
+                           std::move(particle_max_values));
+  }
+
+  template <int dim, typename VectorIds>
+  std::tuple<std::vector<double>,     // particle_radii
+             std::vector<Point<dim>>> // particle_remotes
+  compute_particles_radii(
+    const DoFHandler<dim> &          dof_handler,
+    const VectorIds &                particle_ids,
+    const std::vector<unsigned int> &local_to_global_particle_ids,
+    const unsigned int               local_offset,
+    const std::vector<Point<dim>> &  particle_centers,
+    const bool                       evaluate_remotes    = false,
+    const double                     invalid_particle_id = -1.0)
+  {
+    const auto comm = dof_handler.get_communicator();
+
+    const unsigned int n_particles = particle_centers.size();
+
     // Compute particles radii
     std::vector<double>     particle_radii(n_particles, 0.);
-    std::vector<Point<dim>> particle_remotes(n_particles);
+    std::vector<Point<dim>> particle_remotes(evaluate_remotes ? n_particles :
+                                                                0);
     for (const auto &cell :
          dof_handler.get_triangulation().active_cell_iterators())
       if (cell->is_locally_owned())
@@ -550,7 +571,7 @@ namespace GrainTracker
           const double dist =
             center.distance(cell->barycenter()) + cell->diameter() / 2.;
 
-          if (dist > particle_radii[unique_id])
+          if (evaluate_remotes && dist > particle_radii[unique_id])
             particle_remotes[unique_id] = dist_vec;
 
           particle_radii[unique_id] = std::max(particle_radii[unique_id], dist);
@@ -567,25 +588,26 @@ namespace GrainTracker
                   comm);
 
     // Exchange the remote points
-    for (unsigned int unique_id = 0; unique_id < particle_radii.size();
-         ++unique_id)
-      if (std::abs(particle_radii[unique_id] -
-                   particle_radii_local[unique_id]) > 1e-16)
-        particle_remotes[unique_id] = Point<dim>();
+    if (evaluate_remotes)
+      {
+        // If the current rank is not the owner of the furthest point, then we
+        // nullify it since we perform a global summation later.
+        for (unsigned int unique_id = 0; unique_id < particle_radii.size();
+             ++unique_id)
+          if (std::abs(particle_radii[unique_id] -
+                       particle_radii_local[unique_id]) > 1e-16)
+            particle_remotes[unique_id] = Point<dim>();
 
-    // Perform global communication
-    MPI_Allreduce(MPI_IN_PLACE,
-                  particle_remotes.begin()->begin_raw(),
-                  particle_remotes.size() * dim,
-                  MPI_DOUBLE,
-                  MPI_SUM,
-                  comm);
+        // Perform global communication
+        MPI_Allreduce(MPI_IN_PLACE,
+                      particle_remotes.begin()->begin_raw(),
+                      particle_remotes.size() * dim,
+                      MPI_DOUBLE,
+                      MPI_SUM,
+                      comm);
+      }
 
-    return std::make_tuple(n_particles,
-                           std::move(particle_centers),
-                           std::move(particle_radii),
-                           std::move(particle_measures),
-                           std::move(particle_max_values),
+    return std::make_tuple(std::move(particle_radii),
                            std::move(particle_remotes));
   }
 

--- a/include/pf-applications/grain_tracker/tracker.h
+++ b/include/pf-applications/grain_tracker/tracker.h
@@ -1210,16 +1210,24 @@ namespace GrainTracker
           // Determine properties of particles (volume, radius, center, etc)
           const auto [n_particles,
                       particle_centers,
-                      particle_radii,
                       particle_measures,
-                      particle_max_values,
-                      particle_remotes] =
+                      particle_max_values] =
             compute_particles_info(dof_handler,
                                    particle_ids,
                                    local_to_global_particle_ids,
                                    offset,
                                    invalid_particle_id,
                                    local_particle_max_values);
+
+          // Compute particles radii and remote points (if needed)
+          const auto [particle_radii, particle_remotes] =
+            compute_particles_radii(dof_handler,
+                                    particle_ids,
+                                    local_to_global_particle_ids,
+                                    offset,
+                                    particle_centers,
+                                    elliptical_grains,
+                                    invalid_particle_id);
 
           // Compute particles inertia if needed
           std::vector<double> particle_inertia;

--- a/include/pf-applications/grain_tracker/tracker.h
+++ b/include/pf-applications/grain_tracker/tracker.h
@@ -1212,7 +1212,8 @@ namespace GrainTracker
                       particle_centers,
                       particle_radii,
                       particle_measures,
-                      particle_max_values] =
+                      particle_max_values,
+                      particle_remotes] =
             compute_particles_info(dof_handler,
                                    particle_ids,
                                    local_to_global_particle_ids,

--- a/tests/grain_tracker_elliptical.mpirun=4.output
+++ b/tests/grain_tracker_elliptical.mpirun=4.output
@@ -19,6 +19,6 @@ op_number_changed = false
 Number of order parameters: 1
 Number of grains: 2
 op_index_current = 0 | op_index_old = 0 | segments = 1
-    segment: center = 4.00036 6.50233 | radii = 1.56199 1.58114 | max_value = 1
+    segment: center = 4.00036 6.50233 | radii = 1.63955 1.65964 | max_value = 1
 op_index_current = 0 | op_index_old = 0 | segments = 1
-    segment: center = 4.00241 1.99956 | radii = 1.06383 3.0979 | max_value = 1
+    segment: center = 4.00241 1.99956 | radii = 1.08272 3.15291 | max_value = 1


### PR DESCRIPTION
The ellipsoid radii are evaluated from the 3 principal inertia moments. This is a reasonable approximation that though contains a drawback: for certain geometries the radii may get smaller than the actual grain thus not the whole grain is covered by the ellipsoid. To avoid this, the PR introduces the following scaling algo:
1) identify the outmost point of each grain,
2) if this point is outside of the bounding ellipsoid, then the intersection with the ellipsoid is identified using the previously developed function `find_new_t()` which has been renamed to `find_ellipsoid_intersection()`,
3) the obtained value of `t` is then used to scale the ellipsoid radii preserving thus their aspect ratio.