### PR TITLE
Refactor particles output: particles indices and as spheres

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/driver.h
+++ b/applications/sintering/include/pf-applications/sintering/driver.h
@@ -3565,6 +3565,23 @@ namespace Sintering
           Postprocessors::write_table(table, t, MPI_COMM_WORLD, output);
         }
 
+      if (params.output_data.grains_as_spheres)
+        {
+          const std::string output = params.output_data.vtk_path +
+                                     "/grains_as_spheres_" + label + "." +
+                                     std::to_string(counters[label]) + ".vtu";
+          GrainTracker::output_grains_as_spherical_particles(
+            grain_tracker.get_grains(), dof_handler, output);
+        }
+
+      if (params.output_data.particle_indices)
+        {
+          const std::string output = params.output_data.vtk_path +
+                                     "/particle_ids_" + label + "." +
+                                     std::to_string(counters[label]) + ".vtu";
+          grain_tracker.output_current_particle_ids(output);
+        }
+
       counters[label]++;
     }
 

--- a/applications/sintering/include/pf-applications/sintering/parameters.h
+++ b/applications/sintering/include/pf-applications/sintering/parameters.h
@@ -236,6 +236,8 @@ namespace Sintering
     bool                  fluxes_divergences     = false;
     bool                  concentration_contour  = false;
     bool                  coordination_number    = false;
+    bool                  grains_as_spheres      = false;
+    bool                  particle_indices       = false;
     double                output_time_interval   = 10;
     std::string           vtk_path               = ".";
     std::set<std::string> fields                 = {"CH",
@@ -886,6 +888,12 @@ namespace Sintering
       prm.add_parameter("CoordinationNumber",
                         output_data.coordination_number,
                         "Compute coordination number.");
+      prm.add_parameter("GrainsAsSpheres",
+                        output_data.grains_as_spheres,
+                        "Output grains as spheres using particles framework.");
+      prm.add_parameter("ParticleIndices",
+                        output_data.particle_indices,
+                        "Internal particle indices of the grain tracker.");
       prm.add_parameter("OutputTimeInterval",
                         output_data.output_time_interval,
                         "Output time interval.");

--- a/include/pf-applications/grain_tracker/output.h
+++ b/include/pf-applications/grain_tracker/output.h
@@ -15,6 +15,15 @@
 
 #pragma once
 
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/grid/grid_tools.h>
+
+#include <deal.II/numerics/data_out.h>
+
+#include <deal.II/particles/data_out.h>
+#include <deal.II/particles/particle_handler.h>
+
 #include "grain.h"
 #include "tracking.h"
 

--- a/include/pf-applications/grain_tracker/output.h
+++ b/include/pf-applications/grain_tracker/output.h
@@ -181,4 +181,62 @@ namespace GrainTracker
     data_out.write_vtu_in_parallel(filename, dof_handler.get_communicator());
   }
 
+  // Output clouds as spherical particles
+  template <int dim>
+  void
+  output_grains_as_spherical_particles(
+    const std::map<unsigned int, Grain<dim>> &grains,
+    const DoFHandler<dim> &                   dof_handler,
+    const std::string                         filename)
+  {
+    /* The simplest mapping is provided since it is not employed by the
+     * functionality used in this function. So we do not need here the
+     * original mapping of the problem we are working with.
+     */
+    const MappingQ<dim> mapping(1);
+
+    const unsigned int n_properties = 3;
+
+    Particles::ParticleHandler particles_handler(
+      dof_handler.get_triangulation(), mapping, n_properties);
+    particles_handler.reserve(grains.size());
+
+    MPI_Comm comm = dof_handler.get_communicator();
+
+    const auto local_boxes = GridTools::compute_mesh_predicate_bounding_box(
+      dof_handler.get_triangulation(), IteratorFilters::LocallyOwnedCell());
+    const auto global_bounding_boxes =
+      Utilities::MPI::all_gather(comm, local_boxes);
+
+    std::vector<Point<dim>>          positions;
+    std::vector<std::vector<double>> properties;
+
+    // Append each cloud to the particle handler
+    for (const auto &[gid, grain] : grains)
+      {
+        const unsigned int order_parameter_id = grain.get_order_parameter_id();
+
+        for (const auto &segment : grain.get_segments())
+          {
+            positions.push_back(segment.get_center());
+
+            properties.push_back(
+              std::vector<double>({static_cast<double>(gid),
+                                   segment.get_radius(),
+                                   static_cast<double>(order_parameter_id)}));
+          }
+      }
+
+    particles_handler.insert_global_particles(positions,
+                                              global_bounding_boxes,
+                                              properties);
+
+    Particles::DataOut<dim>  particles_out;
+    std::vector<std::string> data_component_names{"grain_id",
+                                                  "radius",
+                                                  "order_parameter"};
+
+    particles_out.build_patches(particles_handler, data_component_names);
+    particles_out.write_vtu_in_parallel(filename, comm);
+  }
 } // namespace GrainTracker

--- a/include/pf-applications/grain_tracker/tracker.h
+++ b/include/pf-applications/grain_tracker/tracker.h
@@ -1063,11 +1063,12 @@ namespace GrainTracker
         print_grains(old_grains, out);
     }
 
-    // Output last grains
+    // Output current particle ids, mainly used for debugging
     void
-    output_current_grains(std::string prefix = std::string("grains")) const
+    output_current_particle_ids(
+      const std::string filename = std::string("particle_ids.vtu")) const
     {
-      output_grains(grains, prefix);
+      output_particle_ids(op_particle_ids, dof_handler, filename);
     }
 
     /* If there is any particle located at a given cell within a given order
@@ -1826,43 +1827,6 @@ namespace GrainTracker
 
             ++n_total_segments;
           }
-    }
-
-    // Output particle ids
-    void
-    output_particle_ids(const LinearAlgebra::distributed::Vector<double>
-                          &current_particle_ids) const
-    {
-      DataOutBase::VtkFlags flags;
-      flags.write_higher_order_cells = false;
-
-      DataOut<dim> data_out;
-      data_out.set_flags(flags);
-
-      Vector<double> ranks(tria.n_active_cells());
-      ranks = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
-
-      data_out.attach_triangulation(tria);
-
-      data_out.add_data_vector(ranks,
-                               "ranks",
-                               DataOut<dim>::DataVectorType::type_cell_data);
-
-      data_out.add_data_vector(current_particle_ids,
-                               "particle_ids",
-                               DataOut<dim>::DataVectorType::type_cell_data);
-
-      data_out.build_patches();
-
-      pcout << "Outputing particle_ids..." << std::endl;
-
-      static unsigned int counter = 0;
-
-      const std::string filename =
-        "particle_ids." + std::to_string(counter) + ".vtu";
-      data_out.write_vtu_in_parallel(filename, MPI_COMM_WORLD);
-
-      counter++;
     }
 
     // Output clouds as particles (fast)

--- a/include/pf-applications/grain_tracker/tracker.h
+++ b/include/pf-applications/grain_tracker/tracker.h
@@ -1829,68 +1829,6 @@ namespace GrainTracker
           }
     }
 
-    // Output clouds as particles (fast)
-    void
-    output_grains(const std::map<unsigned int, Grain<dim>> &current_grains,
-                  const std::string &                       prefix) const
-    {
-      /* The simplest mapping is provided since it is not employed by the
-       * functionality used in this function. So we do not need here the
-       * original mapping of the problem we are working with.
-       */
-      const MappingQ<dim> mapping(1);
-
-      const unsigned int n_properties = 3;
-
-      Particles::ParticleHandler particles_handler(
-        dof_handler.get_triangulation(), mapping, n_properties);
-      particles_handler.reserve(current_grains.size());
-
-      const auto local_boxes = GridTools::compute_mesh_predicate_bounding_box(
-        dof_handler.get_triangulation(), IteratorFilters::LocallyOwnedCell());
-      const auto global_bounding_boxes =
-        Utilities::MPI::all_gather(MPI_COMM_WORLD, local_boxes);
-
-      std::vector<Point<dim>>          positions;
-      std::vector<std::vector<double>> properties;
-
-      // Append each cloud to the particle handler
-      for (const auto &[gid, grain] : current_grains)
-        {
-          for (const auto &segment : grain.get_segments())
-            {
-              positions.push_back(segment.get_center());
-
-              const unsigned int order_parameter_id =
-                grain.get_order_parameter_id();
-              properties.push_back(
-                std::vector<double>({static_cast<double>(gid),
-                                     segment.get_radius(),
-                                     static_cast<double>(order_parameter_id)}));
-            }
-        }
-
-      particles_handler.insert_global_particles(positions,
-                                                global_bounding_boxes,
-                                                properties);
-
-      Particles::DataOut<dim>  particles_out;
-      std::vector<std::string> data_component_names{"grain_id",
-                                                    "radius",
-                                                    "order_parameter"};
-      particles_out.build_patches(particles_handler, data_component_names);
-
-      pcout << "Outputing grains..." << std::endl;
-
-      static unsigned int counter = 0;
-
-      const std::string filename =
-        prefix + "." + std::to_string(counter) + ".vtu";
-      particles_out.write_vtu_in_parallel(filename, MPI_COMM_WORLD);
-
-      counter++;
-    }
-
     // Print unique log events merged from multiple ranks
     void
     print_log(std::vector<std::string> &log) const


### PR DESCRIPTION
A bit of refactoring of two output functions which are mainly used for debugging of the grain tracker behavior.