### PR TITLE
Improve ellipsoids scaling

### DIFF
--- a/include/pf-applications/grain_tracker/ellipsoid.h
+++ b/include/pf-applications/grain_tracker/ellipsoid.h
@@ -264,6 +264,13 @@ namespace GrainTracker
       return axes;
     }
 
+    bool
+    point_inside(const Point<dim, Number> &p, const Number tol = 1e-9) const
+    {
+      const auto f = 0.5 * (A * p) * p + b * p + alpha;
+      return f <= tol;
+    }
+
   private:
     void
     init_quadratic_form()

--- a/include/pf-applications/grain_tracker/elliptical_helpers.h
+++ b/include/pf-applications/grain_tracker/elliptical_helpers.h
@@ -1,0 +1,86 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2024 by the hpsint authors
+//
+// This file is part of the hpsint library.
+//
+// The hpsint library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.MD at
+// the top level directory of hpsint.
+//
+// ---------------------------------------------------------------------
+
+#pragma once
+
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/point.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <pf-applications/grain_tracker/ellipsoid.h>
+#include <pf-applications/grain_tracker/representation.h>
+
+#include <memory>
+
+namespace GrainTracker
+{
+  using namespace dealii;
+
+  template <int dim, typename VectorIds>
+  std::vector<double>
+  scale_elliptical_representations(
+    const std::vector<std::unique_ptr<RepresentationElliptical<dim>>>
+      &                    representations,
+    const DoFHandler<dim> &dof_handler,
+    const VectorIds &      particle_ids,
+    const double           invalid_particle_id = -1.0)
+  {
+    const auto comm = dof_handler.get_communicator();
+
+    const unsigned int n_particles = representations.size();
+
+    // Compute particles moments of inertia
+    std::vector<double> particle_scales(n_particles, 1.);
+    for (const auto &cell :
+         dof_handler.get_triangulation().active_cell_iterators())
+      if (cell->is_locally_owned())
+        {
+          const auto unique_id = particle_ids[cell->global_active_cell_index()];
+
+          if (unique_id == invalid_particle_id)
+            continue;
+
+          AssertIndexRange(unique_id, n_particles);
+
+          const auto &rep = representations[unique_id];
+          const auto &E   = rep->ellipsoid;
+
+          auto dist_vec = cell->barycenter() - rep->ellipsoid.get_center();
+          dist_vec += (dist_vec / dist_vec.norm()) * cell->diameter() / 2.;
+          const auto p = E.get_center() + dist_vec;
+
+          if (!rep->ellipsoid.point_inside(p))
+            {
+              const auto [t_inter, overlap] =
+                find_ellipsoid_intersection(E, E.get_center(), p);
+
+              if (t_inter > 0 && t_inter < 1)
+                particle_scales[unique_id] =
+                  std::max(1. / t_inter, particle_scales[unique_id]);
+            }
+        }
+
+    // Reduce information - maximum particle scales
+    MPI_Allreduce(MPI_IN_PLACE,
+                  particle_scales.data(),
+                  particle_scales.size(),
+                  MPI_DOUBLE,
+                  MPI_MAX,
+                  comm);
+
+    return particle_scales;
+  }
+} // namespace GrainTracker

--- a/include/pf-applications/grain_tracker/representation.h
+++ b/include/pf-applications/grain_tracker/representation.h
@@ -169,6 +169,11 @@ namespace GrainTracker
       : ellipsoid(center, radii, axes)
     {}
 
+    RepresentationElliptical(const Ellipsoid<dim> &ellipsoid,
+                             const double          scale)
+      : ellipsoid(ellipsoid, scale)
+    {}
+
     RepresentationElliptical(const Ellipsoid<dim> &ellipsoid)
       : ellipsoid(ellipsoid)
     {}

--- a/include/pf-applications/grain_tracker/tracker.h
+++ b/include/pf-applications/grain_tracker/tracker.h
@@ -1440,9 +1440,9 @@ namespace GrainTracker
                 }
 
               /* Additional scaling if needed. Even if the most remote point got
-               * covered by the ellisoid in the previous check, there are still
+               * covered by the ellisoid in the first check, there are still
                * can be points (e.g. located along the axis of the smallest
-               * radius) that fall outside on the ellipsoid. The prvious check
+               * radius) that fall outside on the ellipsoid. The first check
                * minimizes the number of points to be checked at this step. */
               const auto additional_scales =
                 scale_elliptical_representations(representations,

--- a/tests/complex_microstructure.cc
+++ b/tests/complex_microstructure.cc
@@ -13,6 +13,8 @@
 //
 // ---------------------------------------------------------------------
 
+#define MAX_SINTERING_GRAINS 20
+
 #include <deal.II/base/conditional_ostream.h>
 #include <deal.II/base/mpi.h>
 
@@ -236,9 +238,6 @@ main(int argc, char **argv)
     const auto [n_collisions, grains_reassigned, op_number_changed] =
       grain_tracker.initial_setup(solution,
                                   initial_values.n_order_parameters());
-
-    // const std::string prefix = "/mnt/c/Work/HZG/microstructure/";
-    // grain_tracker.output_all_particle_ids(prefix);
 
     pcout << std::boolalpha;
 

--- a/tests/complex_microstructure.mpirun=4.output
+++ b/tests/complex_microstructure.mpirun=4.output
@@ -12,10 +12,10 @@ new_op_number     = 14
 
 Elliptical grain representation:
 n_grains_from_gt  = 81
-n_collisions      = 42
+n_collisions      = 55
 grains_reassigned = true
 op_number_changed = true
-new_op_number     = 9
+new_op_number     = 11
 
 Wavefront grain representation:
 n_grains_from_gt  = 81

--- a/tests/grain_tracker_elliptical.mpirun=4.output
+++ b/tests/grain_tracker_elliptical.mpirun=4.output
@@ -19,6 +19,6 @@ op_number_changed = false
 Number of order parameters: 1
 Number of grains: 2
 op_index_current = 0 | op_index_old = 0 | segments = 1
-    segment: center = 4.00036 6.50233 | radii = 1.63955 1.65964 | max_value = 1
+    segment: center = 4.00036 6.50233 | radii = 1.64862 1.66883 | max_value = 1
 op_index_current = 0 | op_index_old = 0 | segments = 1
-    segment: center = 4.00241 1.99956 | radii = 1.08272 3.15291 | max_value = 1
+    segment: center = 4.00241 1.99956 | radii = 1.12864 3.28663 | max_value = 1


### PR DESCRIPTION
The scaling introduced previously in #687 had a minor error in evaluataion of the scaling factor, but what is more important, it was not sufficient for some cases. Even if the most remote point got covered by the ellisoid in the first check, there are still can be points (e.g. located along the axis of the smallest radius) that fall outside on the ellipsoid. The first check minimizes the number of points to be checked at this step.

Here is the small demonstation how these scalings work (for the grains assigned to the order parameter `op=0`) on the basis of the microstructure test added in #689.

**no scaling**:
![image](https://github.com/user-attachments/assets/c63141d8-3664-4dc0-b0d0-0ebe70ba90cc)

**scaling via the most remote points**:
![without_additional_scaling](https://github.com/user-attachments/assets/0bb4adea-63d1-4cec-b1ad-f5b943766c1b)

**additional scaling**:
![with_additional_scaling](https://github.com/user-attachments/assets/2690178a-720f-4a3c-a174-2cff7a99c956)

The grains drawing is not perfect since the corresponding python script needs improvement, that will be done in the next PR. But still it is possible to see the grains contours and spot the regions not covered by the representation.

With this new additional scaling introduced, aparently, the elliptical representations are now absolutely safe and are guaranteed to cover the entire grains. However, larger ellipsoids are generated and this worsens the behavior of the elliptical grain representation for the test for #690:
| Representation  | # of order parameters | # of collisions during tracking |
| ------------- | ------------- | ------------- |
| original input | 4 | - |
| spherical | 14 | 68 |
| elliptical | ~~9~~ 11 | ~~42~~ 55 |
| wavefront | 6 | 19 |