### PR TITLE
Build elliptical representation and nonconvex grains

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/postprocessors.h
+++ b/applications/sintering/include/pf-applications/sintering/postprocessors.h
@@ -561,7 +561,7 @@ namespace Sintering
       const auto bb = GridTools::compute_bounding_box(
         background_dof_handler.get_triangulation());
 
-      std::vector<Number> parameters((dim + 1) * n_grains, 0);
+      std::vector<Number> parameters;
 
       // Get grain properties from the grain tracker, assume 1 segment per grain
       unsigned int                         g_counter = 0;
@@ -572,10 +572,7 @@ namespace Sintering
 
           const auto &segment = grain.get_segments()[0];
 
-          for (unsigned int d = 0; d < dim; ++d)
-            parameters[g_counter * (dim + 1) + d] = segment.get_center()[d];
-
-          parameters[g_counter * (dim + 1) + dim] = segment.get_radius();
+          segment.save(parameters);
 
           grain_id_to_index.emplace(g, g_counter);
           ++g_counter;

--- a/applications/sintering/scripts/build_tex_packings.py
+++ b/applications/sintering/scripts/build_tex_packings.py
@@ -46,6 +46,8 @@ args = parser.parse_args()
 
 show_labels = args.label_grain_ids or args.label_order_params
 
+max_progress_bar_length = 50
+
 def build_grain(pts_in, dim):
 
     if args.contour_ordering != 'convex':
@@ -132,7 +134,7 @@ def do_job(tasks_to_execute, tasks_completed, n_total):
             
             tasks_completed.put((grain_index, ordered_points))
 
-            library.progress_bar(tasks_completed.qsize(), n_total)
+            library.progress_bar(tasks_completed.qsize(), n_total, max(n_total, max_progress_bar_length))
 
     return True
 
@@ -317,7 +319,7 @@ with open(ofname, 'w') as f:
             print("n_grains to process = {}".format(n_grains_to_process))
 
             # Creating processes and creating contours
-            library.progress_bar(0, n_grains_to_process)
+            library.progress_bar(0, n_grains_to_process, max(n_grains_to_process, max_progress_bar_length))
             for w in range(number_of_processes):
                 p = multiprocessing.Process(target=do_job, args=(tasks_to_execute, tasks_completed, n_grains_to_process))
                 processes.append(p)

--- a/applications/sintering/scripts/build_tex_packings.py
+++ b/applications/sintering/scripts/build_tex_packings.py
@@ -223,7 +223,6 @@ with open(ofname, 'w') as f:
         print("n_grains = {}".format(n_grains))
         print("n_op = {}".format(n_op))
 
-        n_props_to_grain_types = {(dim + 1): 'spherical', (2*dim + dim*dim): 'elliptical', (dim): 'wavefront'}
         grain_types = {
             1: {'label': 'spherical', 'n_data': (dim + 1)},
             2: {'label': 'elliptical', 'n_data': (2*dim + dim*dim)},

--- a/applications/sintering/scripts/library.py
+++ b/applications/sintering/scripts/library.py
@@ -206,3 +206,14 @@ def tex_escape(text):
     }
     regex = re.compile('|'.join(re.escape(str(key)) for key in sorted(conv.keys(), key = lambda item: - len(item))))
     return regex.sub(lambda match: conv[match.group()], text)
+
+# The code is from https://stackoverflow.com/questions/6169217/replace-console-output-in-python
+def progress_bar(current, total, bar_length=20):
+    fraction = current / total
+
+    arrow = int(fraction * bar_length - 1) * '-' + '>'
+    padding = int(bar_length - len(arrow)) * ' '
+
+    ending = '\n' if current == total else '\r'
+
+    print(f'Progress: [{arrow}{padding}] {int(fraction*100)}%', end=ending)

--- a/include/pf-applications/grain_tracker/representation.h
+++ b/include/pf-applications/grain_tracker/representation.h
@@ -145,8 +145,8 @@ namespace GrainTracker
     void
     save(std::vector<double> &output) const override
     {
-      // The nubmer of entries to save
-      output.push_back(dim + 1);
+      // Output representation type
+      output.push_back(1);
 
       std::copy(center.begin_raw(),
                 center.end_raw(),
@@ -239,8 +239,8 @@ namespace GrainTracker
     void
     save(std::vector<double> &output) const override
     {
-      // The nubmer of entries to save
-      output.push_back(dim + dim * dim + dim);
+      // Output representation type
+      output.push_back(2);
 
       const auto &center = ellipsoid.get_center();
       const auto &axes   = ellipsoid.get_axes();
@@ -350,12 +350,21 @@ namespace GrainTracker
     void
     save(std::vector<double> &output) const override
     {
-      // The nubmer of entries to save
-      output.push_back(dim);
+      // Output representation type
+      output.push_back(3);
 
       std::copy(center.begin_raw(),
                 center.end_raw(),
                 std::back_inserter(output));
+
+      double dist_min = std::numeric_limits<double>::max();
+
+      for (const auto &[n_op_and_index, dist] : distances)
+        if (n_op_and_index.first == op_and_index.first && dist < dist_min)
+          dist_min = dist;
+
+      // The offset estimate is the half of the minimum distance
+      output.push_back(dist_min / 2.);
     }
 
     std::pair<unsigned int, unsigned int>                   op_and_index;

--- a/include/pf-applications/grain_tracker/representation.h
+++ b/include/pf-applications/grain_tracker/representation.h
@@ -58,6 +58,12 @@ namespace GrainTracker
     virtual std::unique_ptr<Representation>
     clone() const = 0;
 
+    // It would be nice to be able to provide here custom iterators, but that
+    // would require significatn refactoring to make representation a part of
+    // class Grain and Tracker.
+    virtual void
+    save(std::vector<double> &output) const = 0;
+
     virtual ~Representation()
     {}
 
@@ -134,6 +140,19 @@ namespace GrainTracker
       ar &BOOST_SERIALIZATION_BASE_OBJECT_NVP(Representation);
       ar &center;
       ar &radius;
+    }
+
+    void
+    save(std::vector<double> &output) const override
+    {
+      // The nubmer of entries to save
+      output.push_back(dim + 1);
+
+      std::copy(center.begin_raw(),
+                center.end_raw(),
+                std::back_inserter(output));
+
+      output.push_back(radius);
     }
 
     Point<dim> center;
@@ -215,6 +234,26 @@ namespace GrainTracker
     {
       ar &BOOST_SERIALIZATION_BASE_OBJECT_NVP(Representation);
       ar &ellipsoid;
+    }
+
+    void
+    save(std::vector<double> &output) const override
+    {
+      // The nubmer of entries to save
+      output.push_back(dim + dim * dim + dim);
+
+      const auto &center = ellipsoid.get_center();
+      const auto &axes   = ellipsoid.get_axes();
+      const auto &radii  = ellipsoid.get_radii();
+
+      auto inserter = std::back_inserter(output);
+
+      std::copy(center.begin_raw(), center.end_raw(), inserter);
+
+      for (unsigned int d = 0; d < dim; ++d)
+        std::copy(axes[d].begin_raw(), axes[d].end_raw(), inserter);
+
+      std::copy(radii.cbegin(), radii.cend(), inserter);
     }
 
   private:
@@ -306,6 +345,17 @@ namespace GrainTracker
       ar &op_and_index;
       ar &center;
       ar &distances;
+    }
+
+    void
+    save(std::vector<double> &output) const override
+    {
+      // The nubmer of entries to save
+      output.push_back(dim);
+
+      std::copy(center.begin_raw(),
+                center.end_raw(),
+                std::back_inserter(output));
     }
 
     std::pair<unsigned int, unsigned int>                   op_and_index;

--- a/include/pf-applications/grain_tracker/segment.h
+++ b/include/pf-applications/grain_tracker/segment.h
@@ -112,6 +112,12 @@ namespace GrainTracker
       stream << " | max_value = " << max_value;
     }
 
+    void
+    save(std::vector<double> &output) const
+    {
+      representation->save(output);
+    }
+
     template <class Archive>
     void
     serialize(Archive &ar, const unsigned int /*version*/)

--- a/tests/complex_microstructure.cc
+++ b/tests/complex_microstructure.cc
@@ -35,6 +35,7 @@
 #include <pf-applications/lac/dynamic_block_vector.h>
 
 #include <pf-applications/sintering/initial_values_microstructure.h>
+#include <pf-applications/sintering/postprocessors.h>
 #include <pf-applications/sintering/tools.h>
 
 #include <pf-applications/grain_tracker/distributed_stitching.h>
@@ -265,6 +266,16 @@ main(int argc, char **argv)
                                solution_remap.block(b),
                                output_prefix + "_op_" +
                                  std::to_string(b - op_offset));
+
+    // Output tex
+    const unsigned int n_op =
+      grain_tracker.get_active_order_parameters().size();
+    grain_tracker.track(solution_remap, n_op, true);
+
+    const std::string filename = "81grains_" + label_representation + ".txt";
+
+    Postprocessors::output_grain_contours(
+      mapping, dof_handler, solution_remap, 0.5, filename, n_op, grain_tracker);
   };
 
   // Test various grain tracking representations


### PR DESCRIPTION
This PR adds to features to the tex contours builder:
1. Elliptical grain representations
2. Grains can be nonconvex, `alphashape` from python is used for that. Since the contours building can take a while, this process is done in parallel.

As the result, such nice pictures can be obtained for the microstructure from #689 and #692:
`op=0`:
![image](https://github.com/user-attachments/assets/2c8294c8-108c-43ed-b09f-204768e8b5e8)

`op=1`:
![image](https://github.com/user-attachments/assets/e117e3b2-515e-42af-9941-c5b3a0db064d)
