### PR TITLE
Extract PowerHelper and add a test for it

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/free_energy.h
+++ b/applications/sintering/include/pf-applications/sintering/free_energy.h
@@ -16,106 +16,13 @@
 #pragma once
 
 #include <deal.II/base/utilities.h>
+
+#include <pf-applications/numerics/power_helper.h>
+
 namespace Sintering
 {
   using namespace dealii;
-
-  template <unsigned int n, std::size_t p>
-  class PowerHelper
-  {
-  public:
-    template <typename T>
-    DEAL_II_ALWAYS_INLINE static T
-    power_sum(const T *etas)
-    {
-      T initial = 0.0;
-
-      for (unsigned int i = 0; i < n; ++i)
-        initial += Utilities::fixed_power<p>(etas[i]);
-
-      return initial;
-    }
-
-    template <typename T>
-    DEAL_II_ALWAYS_INLINE static T
-    power_sum(const std::array<T, n> &etas)
-    {
-      T initial = 0.0;
-
-      return std::accumulate(
-        etas.begin(), etas.end(), initial, [](auto a, auto b) {
-          return std::move(a) + Utilities::fixed_power<p>(b);
-        });
-    }
-
-    template <typename T>
-    DEAL_II_ALWAYS_INLINE static T
-    power_sum(const std::vector<T> &etas)
-    {
-      T initial = 0.0;
-
-      return std::accumulate(
-        etas.begin(), etas.end(), initial, [](auto a, auto b) {
-          return std::move(a) + Utilities::fixed_power<p>(b);
-        });
-    }
-  };
-
-  template <>
-  class PowerHelper<2, 2>
-  {
-  public:
-    template <typename T>
-    DEAL_II_ALWAYS_INLINE static T
-    power_sum(const T *etas)
-    {
-      return etas[0] * etas[0] + etas[1] * etas[1];
-    }
-
-    template <typename T>
-    DEAL_II_ALWAYS_INLINE static T
-    power_sum(const std::array<T, 2> &etas)
-    {
-      return etas[0] * etas[0] + etas[1] * etas[1];
-    }
-  };
-
-  template <>
-  class PowerHelper<2, 3>
-  {
-  public:
-    template <typename T>
-    DEAL_II_ALWAYS_INLINE static T
-    power_sum(const T *etas)
-    {
-      return etas[0] * etas[0] * etas[0] + etas[1] * etas[1] * etas[1];
-    }
-
-    template <typename T>
-    DEAL_II_ALWAYS_INLINE static T
-    power_sum(const std::array<T, 2> &etas)
-    {
-      return etas[0] * etas[0] * etas[0] + etas[1] * etas[1] * etas[1];
-    }
-  };
-
-  template <class T>
-  class SizeHelper;
-
-  template <class T, std::size_t n>
-  class SizeHelper<std::array<T, n>>
-  {
-  public:
-    static const std::size_t size = n;
-  };
-
-  template <class T>
-  class SizeHelper<std::vector<T>>
-  {
-  public:
-    static const std::size_t size = 0;
-  };
-
+  using namespace hpsint;
 
   template <typename VectorizedArrayType>
   class FreeEnergy

--- a/include/pf-applications/numerics/power_helper.h
+++ b/include/pf-applications/numerics/power_helper.h
@@ -1,0 +1,153 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2024 by the hpsint authors
+//
+// This file is part of the hpsint library.
+//
+// The hpsint library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.MD at
+// the top level directory of hpsint.
+//
+// ---------------------------------------------------------------------
+
+#pragma once
+
+#include <deal.II/base/utilities.h>
+
+namespace hpsint
+{
+  using namespace dealii;
+
+  template <unsigned int n, std::size_t p>
+  class PowerHelper
+  {
+  public:
+    template <typename T>
+    DEAL_II_ALWAYS_INLINE static T
+    power_sum(const T *etas)
+    {
+      T initial = 0.0;
+
+      for (unsigned int i = 0; i < n; ++i)
+        initial += Utilities::fixed_power<p>(etas[i]);
+
+      return initial;
+    }
+
+    template <typename T>
+    DEAL_II_ALWAYS_INLINE static T
+    power_sum(const std::array<T, n> &etas)
+    {
+      T initial = 0.0;
+
+      return std::accumulate(
+        etas.begin(), etas.end(), initial, [](auto a, auto b) {
+          return std::move(a) + Utilities::fixed_power<p>(b);
+        });
+    }
+
+    template <typename T>
+    DEAL_II_ALWAYS_INLINE static T
+    power_sum(const Tensor<1, n, T> &etas)
+    {
+      T initial = 0.0;
+
+      return std::accumulate(
+        etas.begin_raw(), etas.end_raw(), initial, [](auto a, auto b) {
+          return std::move(a) + Utilities::fixed_power<p>(b);
+        });
+    }
+
+    template <typename T>
+    DEAL_II_ALWAYS_INLINE static T
+    power_sum(const std::vector<T> &etas)
+    {
+      T initial = 0.0;
+
+      return std::accumulate(
+        etas.begin(), etas.end(), initial, [](auto a, auto b) {
+          return std::move(a) + Utilities::fixed_power<p>(b);
+        });
+    }
+  };
+
+  template <>
+  class PowerHelper<2, 2>
+  {
+  public:
+    template <typename T>
+    DEAL_II_ALWAYS_INLINE static T
+    power_sum(const T *etas)
+    {
+      return etas[0] * etas[0] + etas[1] * etas[1];
+    }
+
+    template <typename T>
+    DEAL_II_ALWAYS_INLINE static T
+    power_sum(const std::array<T, 2> &etas)
+    {
+      return etas[0] * etas[0] + etas[1] * etas[1];
+    }
+
+    template <typename T>
+    DEAL_II_ALWAYS_INLINE static T
+    power_sum(const Tensor<1, 2, T> &etas)
+    {
+      return etas[0] * etas[0] + etas[1] * etas[1];
+    }
+  };
+
+  template <>
+  class PowerHelper<2, 3>
+  {
+  public:
+    template <typename T>
+    DEAL_II_ALWAYS_INLINE static T
+    power_sum(const T *etas)
+    {
+      return etas[0] * etas[0] * etas[0] + etas[1] * etas[1] * etas[1];
+    }
+
+    template <typename T>
+    DEAL_II_ALWAYS_INLINE static T
+    power_sum(const std::array<T, 2> &etas)
+    {
+      return etas[0] * etas[0] * etas[0] + etas[1] * etas[1] * etas[1];
+    }
+
+    template <typename T>
+    DEAL_II_ALWAYS_INLINE static T
+    power_sum(const Tensor<1, 2, T> &etas)
+    {
+      return etas[0] * etas[0] * etas[0] + etas[1] * etas[1] * etas[1];
+    }
+  };
+
+
+  template <class T>
+  class SizeHelper;
+
+  template <class T, std::size_t n>
+  class SizeHelper<std::array<T, n>>
+  {
+  public:
+    static const std::size_t size = n;
+  };
+
+  template <int dim, class T>
+  class SizeHelper<Tensor<1, dim, T>>
+  {
+  public:
+    static const std::size_t size = dim;
+  };
+
+  template <class T>
+  class SizeHelper<std::vector<T>>
+  {
+  public:
+    static const std::size_t size = 0;
+  };
+} // namespace hpsint

--- a/tests/power_sum.cc
+++ b/tests/power_sum.cc
@@ -57,7 +57,7 @@ main()
   std::cout << "p=4: " << PowerHelper<n_grains, 4>::power_sum(ten) << std::endl;
 
   // Test raw pointers
-  const auto ptr  = arr.data();
+  const auto ptr = arr.data();
   std::cout << "pointer data = ";
   dump(ptr, ptr + n_grains);
   std::cout << "p=1: " << PowerHelper<n_grains, 1>::power_sum(ptr) << std::endl;

--- a/tests/power_sum.cc
+++ b/tests/power_sum.cc
@@ -1,0 +1,97 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2024 by the hpsint authors
+//
+// This file is part of the hpsint library.
+//
+// The hpsint library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.MD at
+// the top level directory of hpsint.
+//
+// ---------------------------------------------------------------------
+
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/tensor.h>
+
+#include <pf-applications/numerics/power_helper.h>
+
+#include <array>
+#include <vector>
+
+using namespace dealii;
+using namespace hpsint;
+
+int
+main()
+{
+  const auto dump = [](const auto &begin, const auto &end) {
+    std::copy(begin, end, std::ostream_iterator<double>(std::cout, " "));
+    std::cout << std::endl;
+  };
+
+  // Non-optimized versions
+  constexpr unsigned int n_grains = 4;
+
+  std::cout << "Generalized versions:" << std::endl;
+
+  // Test an array
+  std::array<double, n_grains> arr = {{3., 4., 2., -5.}};
+  std::cout << "std::array = ";
+  dump(arr.begin(), arr.end());
+  std::cout << "p=1: " << PowerHelper<n_grains, 1>::power_sum(arr) << std::endl;
+  std::cout << "p=2: " << PowerHelper<n_grains, 2>::power_sum(arr) << std::endl;
+  std::cout << "p=3: " << PowerHelper<n_grains, 3>::power_sum(arr) << std::endl;
+  std::cout << "p=4: " << PowerHelper<n_grains, 4>::power_sum(arr) << std::endl;
+
+  // Test a first-order tenor
+  const Tensor<1, n_grains, double> ten(
+    ArrayView<double>(arr.data(), n_grains));
+  std::cout << "Tensor = ";
+  dump(ten.begin_raw(), ten.end_raw());
+  std::cout << "p=1: " << PowerHelper<n_grains, 1>::power_sum(ten) << std::endl;
+  std::cout << "p=2: " << PowerHelper<n_grains, 2>::power_sum(ten) << std::endl;
+  std::cout << "p=3: " << PowerHelper<n_grains, 3>::power_sum(ten) << std::endl;
+  std::cout << "p=4: " << PowerHelper<n_grains, 4>::power_sum(ten) << std::endl;
+
+  // Test raw pointers
+  const auto ptr  = arr.data();
+  std::cout << "pointer data = ";
+  dump(ptr, ptr + n_grains);
+  std::cout << "p=1: " << PowerHelper<n_grains, 1>::power_sum(ptr) << std::endl;
+  std::cout << "p=2: " << PowerHelper<n_grains, 2>::power_sum(ptr) << std::endl;
+  std::cout << "p=3: " << PowerHelper<n_grains, 3>::power_sum(ptr) << std::endl;
+  std::cout << "p=4: " << PowerHelper<n_grains, 4>::power_sum(ptr) << std::endl;
+
+  // Test vector
+  const std::vector<double> vec(arr.begin(), arr.end());
+  std::cout << "std::vector = ";
+  dump(vec.begin(), vec.end());
+  std::cout << "p=1: " << PowerHelper<n_grains, 1>::power_sum(vec) << std::endl;
+  std::cout << "p=2: " << PowerHelper<n_grains, 2>::power_sum(vec) << std::endl;
+  std::cout << "p=3: " << PowerHelper<n_grains, 3>::power_sum(vec) << std::endl;
+  std::cout << "p=4: " << PowerHelper<n_grains, 4>::power_sum(vec) << std::endl;
+
+  // Optimized versions
+  std::cout << "Optimized versions:" << std::endl;
+
+  std::array<double, 2> arr_small = {{3., 4.}};
+  std::cout << "std::array = ";
+  dump(arr_small.begin(), arr_small.end());
+  std::cout << "p=2: " << PowerHelper<2, 2>::power_sum(arr_small) << std::endl;
+  std::cout << "p=3: " << PowerHelper<2, 3>::power_sum(arr_small) << std::endl;
+
+  const Tensor<1, 2, double> ten_small(ArrayView<double>(arr_small.data(), 2));
+  std::cout << "Tensor = ";
+  dump(ten_small.begin_raw(), ten_small.end_raw());
+  std::cout << "p=2: " << PowerHelper<2, 2>::power_sum(ten_small) << std::endl;
+  std::cout << "p=3: " << PowerHelper<2, 3>::power_sum(ten_small) << std::endl;
+
+  const auto ptr_small = arr_small.data();
+  std::cout << "pointer data = ";
+  dump(ptr, ptr + 2);
+  std::cout << "p=2: " << PowerHelper<2, 2>::power_sum(ptr_small) << std::endl;
+  std::cout << "p=3: " << PowerHelper<2, 3>::power_sum(ptr_small) << std::endl;
+}

--- a/tests/power_sum.output
+++ b/tests/power_sum.output
@@ -1,0 +1,31 @@
+Generalized versions:
+std::array = 3 4 2 -5
+p=1: 4
+p=2: 54
+p=3: -26
+p=4: 978
+Tensor = 3 4 2 -5
+p=1: 4
+p=2: 54
+p=3: -26
+p=4: 978
+pointer data = 3 4 2 -5
+p=1: 4
+p=2: 54
+p=3: -26
+p=4: 978
+std::vector = 3 4 2 -5
+p=1: 4
+p=2: 54
+p=3: -26
+p=4: 978
+Optimized versions:
+std::array = 3 4
+p=2: 25
+p=3: 91
+Tensor = 3 4
+p=2: 25
+p=3: 91
+pointer data = 3 4
+p=2: 25
+p=3: 91


### PR DESCRIPTION
For the proper implementation of the grain growth model, we need to refactor a bit the existing code to make it not so much dependent on the energy functional and on the number of unknown fields (i.e., sometimes we do not have CH or AC components at all). This is a first PR in a sequence to implement this.