### PR TITLE
FDM approximation of the system matrix for preconditioners

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/driver.h
+++ b/applications/sintering/include/pf-applications/sintering/driver.h
@@ -61,6 +61,7 @@
 #include <pf-applications/base/solution_serialization.h>
 #include <pf-applications/base/timer.h>
 
+#include <pf-applications/lac/evaluation.h>
 #include <pf-applications/lac/solvers_linear.h>
 #include <pf-applications/lac/solvers_nonlinear.h>
 
@@ -1315,6 +1316,19 @@ namespace Sintering
                   params.advection_data.enable,
                   save_all_blocks);
               }
+          }
+
+        // Use numerical approximation of the underlying system, if a
+        // preconditiner uses it, of course. Mainly, a debug feature.
+        if (params.nonlinear_data.fdm_precond_system_approximation)
+          {
+            auto &system_matrix = nonlinear_operator.get_system_matrix();
+
+            calc_numeric_tangent(dof_handler,
+                                 nonlinear_operator,
+                                 current_u,
+                                 nl_residual,
+                                 system_matrix);
           }
 
         preconditioner->do_update();

--- a/applications/sintering/include/pf-applications/sintering/driver.h
+++ b/applications/sintering/include/pf-applications/sintering/driver.h
@@ -1257,68 +1257,13 @@ namespace Sintering
           {
             AssertThrow(params.matrix_based, ExcNotImplemented());
 
-            const double epsilon   = 1e-7;
-            const double tolerance = 1e-12;
-
             auto &system_matrix = nonlinear_operator.get_system_matrix();
 
-            const unsigned int n_blocks = current_u.n_blocks();
-
-            // for (unsigned int b = 0; b < n_blocks; ++b)
-            //  for (unsigned int i = 0; i < current_u.block(b).size();
-            //  ++i)
-            //    if(constraints.is_constrained (i))
-            //                system_matrix.set(b + i * n_blocks,
-            //                                  b + i * n_blocks,
-            //                                  1.0);
-
-            system_matrix = 0.0;
-
-            VectorType src, dst, dst_;
-            src.reinit(current_u);
-            dst.reinit(current_u);
-            dst_.reinit(current_u);
-
-            src.copy_locally_owned_data_from(current_u);
-
-            nl_residual(src, dst_);
-
-            const auto locally_owned_dofs = dof_handler.locally_owned_dofs();
-
-            for (unsigned int b = 0; b < n_blocks; ++b)
-              for (unsigned int i = 0; i < current_u.block(b).size(); ++i)
-                {
-                  if (locally_owned_dofs.is_element(i))
-                    src.block(b)[i] += epsilon;
-
-                  nl_residual(src, dst);
-
-                  if (locally_owned_dofs.is_element(i))
-                    src.block(b)[i] -= epsilon;
-
-                  for (unsigned int b_ = 0; b_ < n_blocks; ++b_)
-                    for (unsigned int i_ = 0; i_ < current_u.block(b).size();
-                         ++i_)
-                      if (locally_owned_dofs.is_element(i_))
-                        {
-                          if (nonlinear_operator.get_sparsity_pattern().exists(
-                                b_ + i_ * n_blocks, b + i * n_blocks))
-                            {
-                              const Number value =
-                                (dst.block(b_)[i_] - dst_.block(b_)[i_]) /
-                                epsilon;
-
-                              if (std::abs(value) > tolerance)
-                                system_matrix.set(b_ + i_ * n_blocks,
-                                                  b + i * n_blocks,
-                                                  value);
-                              else if ((b == b_) && (i == i_))
-                                system_matrix.set(b_ + i_ * n_blocks,
-                                                  b + i * n_blocks,
-                                                  1.0);
-                            }
-                        }
-                }
+            calc_numeric_tangent(dof_handler,
+                                 nonlinear_operator,
+                                 current_u,
+                                 nl_residual,
+                                 system_matrix);
           }
 
         jacobian_operator->reinit(current_u);

--- a/applications/sintering/include/pf-applications/sintering/operator_base.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_base.h
@@ -531,7 +531,7 @@ namespace Sintering
 
     void
     initialize_block_system_matrix(const bool compute     = true,
-                             const bool print_stats = true) const
+                                   const bool print_stats = true) const
     {
       const bool system_matrix_is_empty = block_system_matrix.size() == 0;
 
@@ -567,15 +567,15 @@ namespace Sintering
 
           if (print_stats)
             {
-          this->pcout << std::endl;
-          this->pcout << "Create block sparsity pattern (" << this->label
-                      << ") with:" << std::endl;
-          this->pcout << " - number of blocks: " << this->n_components()
-                      << std::endl;
-          this->pcout << " - NNZ:              "
-                      << block_system_matrix[0]->n_nonzero_elements()
-                      << std::endl;
-          this->pcout << std::endl;
+              this->pcout << std::endl;
+              this->pcout << "Create block sparsity pattern (" << this->label
+                          << ") with:" << std::endl;
+              this->pcout << " - number of blocks: " << this->n_components()
+                          << std::endl;
+              this->pcout << " - NNZ:              "
+                          << block_system_matrix[0]->n_nonzero_elements()
+                          << std::endl;
+              this->pcout << std::endl;
             }
         }
 

--- a/applications/sintering/include/pf-applications/sintering/operator_base.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_base.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2023 by the hpsint authors
+// Copyright (C) 2023 - 2024 by the hpsint authors
 //
 // This file is part of the hpsint library.
 //
@@ -395,21 +395,18 @@ namespace Sintering
     TrilinosWrappers::SparseMatrix &
     get_system_matrix()
     {
-      initialize_system_matrix();
-
       return system_matrix;
     }
 
     const TrilinosWrappers::SparseMatrix &
     get_system_matrix() const
     {
-      initialize_system_matrix();
-
       return system_matrix;
     }
 
     void
-    initialize_system_matrix(const bool print_stats = true) const
+    initialize_system_matrix(const bool compute     = true,
+                             const bool print_stats = true) const
     {
       const bool system_matrix_is_empty =
         system_matrix.m() == 0 || system_matrix.n() == 0;
@@ -459,6 +456,9 @@ namespace Sintering
               this->pcout << std::endl;
             }
         }
+
+      if (compute == false)
+        return;
 
       {
         MyScope scope(this->timer,

--- a/applications/sintering/include/pf-applications/sintering/operator_base.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_base.h
@@ -526,6 +526,13 @@ namespace Sintering
     const std::vector<std::shared_ptr<TrilinosWrappers::SparseMatrix>> &
     get_block_system_matrix() const
     {
+      return block_system_matrix;
+    }
+
+    void
+    initialize_block_system_matrix(const bool compute     = true,
+                             const bool print_stats = true) const
+    {
       const bool system_matrix_is_empty = block_system_matrix.size() == 0;
 
       if (system_matrix_is_empty)
@@ -558,6 +565,8 @@ namespace Sintering
               block_system_matrix[b]->reinit(dsp);
             }
 
+          if (print_stats)
+            {
           this->pcout << std::endl;
           this->pcout << "Create block sparsity pattern (" << this->label
                       << ") with:" << std::endl;
@@ -567,7 +576,11 @@ namespace Sintering
                       << block_system_matrix[0]->n_nonzero_elements()
                       << std::endl;
           this->pcout << std::endl;
+            }
         }
+
+      if (compute == false)
+        return;
 
       {
         MyScope scope(this->timer,
@@ -588,8 +601,6 @@ namespace Sintering
         EXPAND_OPERATIONS(OPERATION);
 #undef OPERATION
       }
-
-      return block_system_matrix;
     }
 
     void

--- a/applications/sintering/include/pf-applications/sintering/parameters.h
+++ b/applications/sintering/include/pf-applications/sintering/parameters.h
@@ -336,8 +336,9 @@ namespace Sintering
 
     std::string nonlinear_solver_type = "damped";
 
-    bool fdm_jacobian_approximation = false;
-    bool jacobi_free                = false;
+    bool fdm_jacobian_approximation       = false;
+    bool fdm_precond_system_approximation = false;
+    bool jacobi_free                      = false;
 
     unsigned int verbosity = 1;
 
@@ -1038,6 +1039,8 @@ namespace Sintering
 
       prm.add_parameter("FDMJacobianApproximation",
                         nonlinear_data.fdm_jacobian_approximation);
+      prm.add_parameter("FDMPrecondSystemApproximation",
+                        nonlinear_data.fdm_precond_system_approximation);
       prm.add_parameter("JacobiFree", nonlinear_data.jacobi_free);
       prm.add_parameter("Verbosity", nonlinear_data.verbosity);
 

--- a/applications/sintering/include/pf-applications/sintering/preconditioners.h
+++ b/applications/sintering/include/pf-applications/sintering/preconditioners.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2023 by the hpsint authors
+// Copyright (C) 2023 - 2024 by the hpsint authors
 //
 // This file is part of the hpsint library.
 //

--- a/applications/sintering/include/pf-applications/sintering/preconditioners.h
+++ b/applications/sintering/include/pf-applications/sintering/preconditioners.h
@@ -1268,6 +1268,24 @@ namespace Sintering
         }
     }
 
+    Preconditioners::UnderlyingEntity
+    underlying_entity() override
+    {
+      Preconditioners::UnderlyingEntity underlying =
+        Preconditioners::UnderlyingEntity::None;
+
+      if (preconditioner_0)
+        underlying |= preconditioner_0->underlying_entity();
+
+      if (preconditioner_1)
+        underlying |= preconditioner_1->underlying_entity();
+
+      if (preconditioner_2)
+        underlying |= preconditioner_2->underlying_entity();
+
+      return underlying;
+    }
+
     virtual std::size_t
     memory_consumption() const override
     {

--- a/applications/sintering/sintering_throughput.cc
+++ b/applications/sintering/sintering_throughput.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2022 by the deal.II authors
+// Copyright (C) 2022 - 2024 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -214,6 +214,8 @@ main(int argc, char **argv)
 
     if (op.n_components() <= 2 + max_sintering_grains_mb) // ... matrix-based
       {
+        op.initialize_system_matrix();
+
         const auto &matrix = op.get_system_matrix();
 
         const auto partitioner = op.get_system_partitioner();

--- a/include/pf-applications/lac/evaluation.h
+++ b/include/pf-applications/lac/evaluation.h
@@ -1,0 +1,88 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2024 by the hpsint authors
+//
+// This file is part of the hpsint library.
+//
+// The hpsint library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.MD at
+// the top level directory of hpsint.
+//
+// ---------------------------------------------------------------------
+
+#pragma once
+
+#include <deal.II/dofs/dof_handler.h>
+
+namespace hpsint
+{
+  using namespace dealii;
+  using namespace Sintering;
+
+  template <int dim,
+            typename VectorType,
+            typename MatrixType,
+            typename Residual,
+            typename NonLinearOperator>
+  void
+  calc_numeric_tangent(const DoFHandler<dim> &  dof_handler,
+                       const NonLinearOperator &nonlinear_operator,
+                       const VectorType &       linearization_point,
+                       Residual                 nl_residual,
+                       MatrixType &             tangent_numeric,
+                       const double             epsilon   = 1e-7,
+                       const double             tolerance = 1e-12)
+  {
+    VectorType residual;
+
+    nonlinear_operator.initialize_dof_vector(residual);
+    nl_residual(linearization_point, residual);
+
+    const VectorType residual0(residual);
+    VectorType       state(linearization_point);
+
+    const auto locally_owned_dofs = dof_handler.locally_owned_dofs();
+    const auto n_blocks           = state.n_blocks();
+
+    for (unsigned int b = 0; b < n_blocks; ++b)
+      for (unsigned int i = 0; i < state.block(b).size(); ++i)
+        {
+          VectorType residual1(residual);
+          residual1 = 0;
+
+          if (locally_owned_dofs.is_element(i))
+            state.block(b)[i] += epsilon;
+
+          nl_residual(state, residual1);
+
+          if (locally_owned_dofs.is_element(i))
+            state.block(b)[i] -= epsilon;
+
+          for (unsigned int b_ = 0; b_ < n_blocks; ++b_)
+            for (unsigned int i_ = 0; i_ < state.block(b).size(); ++i_)
+              if (locally_owned_dofs.is_element(i_))
+                {
+                  if (nonlinear_operator.get_sparsity_pattern().exists(
+                        b_ + i_ * n_blocks, b + i * n_blocks))
+                    {
+                      const auto value =
+                        (residual1.block(b_)[i_] - residual0.block(b_)[i_]) /
+                        epsilon;
+
+                      if (std::abs(value) > tolerance)
+                        tangent_numeric.set(b_ + i_ * n_blocks,
+                                            b + i * n_blocks,
+                                            value);
+
+                      else if ((b == b_) && (i == i_))
+                        tangent_numeric.set(b_ + i_ * n_blocks,
+                                            b + i * n_blocks,
+                                            1.0);
+                    }
+                }
+        }
+  }
+} // namespace hpsint

--- a/include/pf-applications/lac/preconditioners.h
+++ b/include/pf-applications/lac/preconditioners.h
@@ -37,6 +37,14 @@ namespace Preconditioners
 {
   using namespace dealii;
 
+  enum class UnderlyingEntity
+  {
+    None        = 0x00,
+    System      = 0x01,
+    BlockSystem = 0x02
+  };
+
+
   template <typename Number>
   class PreconditionerBase
   {
@@ -69,6 +77,9 @@ namespace Preconditioners
 
     virtual void
     do_update() = 0;
+
+    virtual UnderlyingEntity
+    underlying_entity() = 0;
   };
 
 
@@ -102,6 +113,12 @@ namespace Preconditioners
     void
     do_update() override
     {}
+
+    UnderlyingEntity
+    underlying_entity() override
+    {
+      return UnderlyingEntity::None;
+    }
 
     virtual std::size_t
     memory_consumption() const override
@@ -148,6 +165,12 @@ namespace Preconditioners
     do_update() override
     {
       op.compute_inverse_diagonal(diagonal_matrix.get_vector());
+    }
+
+    UnderlyingEntity
+    underlying_entity() override
+    {
+      return UnderlyingEntity::None;
     }
 
     virtual std::size_t
@@ -250,6 +273,12 @@ namespace Preconditioners
         }
     }
 
+    UnderlyingEntity
+    underlying_entity() override
+    {
+      return UnderlyingEntity::System;
+    }
+
   private:
     const Operator &                op;
     std::vector<FullMatrix<Number>> diagonal_matrix;
@@ -349,6 +378,11 @@ namespace Preconditioners
       weights.update_ghost_values();
     }
 
+    UnderlyingEntity
+    underlying_entity() override
+    {
+      return UnderlyingEntity::System;
+    }
 
   private:
     static void
@@ -599,6 +633,12 @@ namespace Preconditioners
       precondition_amg.initialize(op.get_system_matrix(), additional_data);
     }
 
+    UnderlyingEntity
+    underlying_entity() override
+    {
+      return UnderlyingEntity::System;
+    }
+
     virtual std::size_t
     memory_consumption() const override
     {
@@ -672,6 +712,12 @@ namespace Preconditioners
             std::make_shared<TrilinosWrappers::PreconditionAMG>();
           precondition_amg[b]->initialize(*block_matrix[b], additional_data);
         }
+    }
+
+    UnderlyingEntity
+    underlying_entity() override
+    {
+      return UnderlyingEntity::BlockSystem;
     }
 
     virtual std::size_t
@@ -755,6 +801,12 @@ namespace Preconditioners
     {
       MyScope scope(timer, "ilu::setup");
       precondition_ilu.initialize(op.get_system_matrix(), additional_data);
+    }
+
+    UnderlyingEntity
+    underlying_entity() override
+    {
+      return UnderlyingEntity::System;
     }
 
     virtual std::size_t
@@ -881,6 +933,12 @@ namespace Preconditioners
             std::make_shared<TrilinosWrappers::PreconditionILU>();
           precondition_ilu[b]->initialize(*block_matrix[b], additional_data);
         }
+    }
+
+    UnderlyingEntity
+    underlying_entity() override
+    {
+      return UnderlyingEntity::BlockSystem;
     }
 
     virtual std::size_t
@@ -1138,6 +1196,12 @@ namespace Preconditioners
         else
           timer.leave_subsection(label);
       });
+    }
+
+    UnderlyingEntity
+    underlying_entity() override
+    {
+      return UnderlyingEntity::None;
     }
 
   private:

--- a/include/pf-applications/lac/preconditioners.h
+++ b/include/pf-applications/lac/preconditioners.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2023 by the hpsint authors
+// Copyright (C) 2023 - 2024 by the hpsint authors
 //
 // This file is part of the hpsint library.
 //

--- a/include/pf-applications/lac/preconditioners.h
+++ b/include/pf-applications/lac/preconditioners.h
@@ -44,6 +44,31 @@ namespace Preconditioners
     BlockSystem = 0x02
   };
 
+  inline UnderlyingEntity
+  operator|(UnderlyingEntity a, UnderlyingEntity b)
+  {
+    return static_cast<UnderlyingEntity>(static_cast<int>(a) |
+                                         static_cast<int>(b));
+  }
+
+  inline UnderlyingEntity
+  operator&(UnderlyingEntity a, UnderlyingEntity b)
+  {
+    return static_cast<UnderlyingEntity>(static_cast<int>(a) &
+                                         static_cast<int>(b));
+  }
+
+  inline UnderlyingEntity &
+  operator|=(UnderlyingEntity &a, UnderlyingEntity b)
+  {
+    return a = a | b;
+  }
+
+  inline UnderlyingEntity &
+  operator&=(UnderlyingEntity &a, UnderlyingEntity b)
+  {
+    return a = a & b;
+  }
 
   template <typename Number>
   class PreconditionerBase

--- a/tests/include/pf-applications/tests/tangent_tester.h
+++ b/tests/include/pf-applications/tests/tangent_tester.h
@@ -1,3 +1,18 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2024 by the hpsint authors
+//
+// This file is part of the hpsint library.
+//
+// The hpsint library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.MD at
+// the top level directory of hpsint.
+//
+// ---------------------------------------------------------------------
+
 #include <deal.II/base/conditional_ostream.h>
 
 #include <pf-applications/tests/sintering_model.h>

--- a/tests/include/pf-applications/tests/tangent_tester.h
+++ b/tests/include/pf-applications/tests/tangent_tester.h
@@ -15,9 +15,9 @@
 
 #include <deal.II/base/conditional_ostream.h>
 
-#include <pf-applications/tests/sintering_model.h>
-
 #include <pf-applications/lac/evaluation.h>
+
+#include <pf-applications/tests/sintering_model.h>
 
 #include <iostream>
 
@@ -58,13 +58,12 @@ namespace Test
     ConditionalOStream pcout(std::cout, is_zero_rank);
 
     // How to compute residual
-    auto nl_residual =
-      [&](const auto &src, auto &dst) {
-        if (enable_rbm)
-          advection_operator.evaluate_forces(src);
+    auto nl_residual = [&](const auto &src, auto &dst) {
+      if (enable_rbm)
+        advection_operator.evaluate_forces(src);
 
-        nonlinear_operator.evaluate_nonlinear_residual(dst, src);
-      };
+      nonlinear_operator.evaluate_nonlinear_residual(dst, src);
+    };
 
     // Evaluate residual (used for debug and to init advection data structures)
     VectorType residual;

--- a/tests/include/pf-applications/tests/tangent_tester.h
+++ b/tests/include/pf-applications/tests/tangent_tester.h
@@ -75,7 +75,7 @@ namespace Test
 
     // At first compute analytic matrix
     FullMatrix<Number> tangent_analytic(n_dofs, n_dofs);
-    nonlinear_operator.initialize_system_matrix(false);
+    nonlinear_operator.initialize_system_matrix(true, false);
     tangent_analytic.copy_from(nonlinear_operator.get_system_matrix());
 
     // Then compute analytic matrix

--- a/tests/include/pf-applications/tests/tangent_tester.h
+++ b/tests/include/pf-applications/tests/tangent_tester.h
@@ -2,76 +2,15 @@
 
 #include <pf-applications/tests/sintering_model.h>
 
+#include <pf-applications/lac/evaluation.h>
+
 #include <iostream>
 
 namespace Test
 {
   using namespace dealii;
+  using namespace hpsint;
   using namespace Sintering;
-
-  template <int dim,
-            typename VectorType,
-            typename MatrixType,
-            typename NonLinearOperator>
-  void
-  calc_numeric_tangent(
-    const DoFHandler<dim> &                               dof_handler,
-    const NonLinearOperator &                             nonlinear_operator,
-    const VectorType &                                    linearization_point,
-    std::function<void(const VectorType &, VectorType &)> nl_residual,
-    MatrixType &                                          tangent_numeric,
-    const double                                          epsilon   = 1e-7,
-    const double                                          tolerance = 1e-12)
-  {
-    VectorType residual;
-
-    nonlinear_operator.initialize_dof_vector(residual);
-    nl_residual(linearization_point, residual);
-
-    const VectorType residual0(residual);
-    VectorType       state(linearization_point);
-
-    const auto locally_owned_dofs = dof_handler.locally_owned_dofs();
-    const auto n_blocks           = state.n_blocks();
-
-    for (unsigned int b = 0; b < n_blocks; ++b)
-      for (unsigned int i = 0; i < state.block(b).size(); ++i)
-        {
-          VectorType residual1(residual);
-          residual1 = 0;
-
-          if (locally_owned_dofs.is_element(i))
-            state.block(b)[i] += epsilon;
-
-          nl_residual(state, residual1);
-
-          if (locally_owned_dofs.is_element(i))
-            state.block(b)[i] -= epsilon;
-
-          for (unsigned int b_ = 0; b_ < n_blocks; ++b_)
-            for (unsigned int i_ = 0; i_ < state.block(b).size(); ++i_)
-              if (locally_owned_dofs.is_element(i_))
-                {
-                  if (nonlinear_operator.get_sparsity_pattern().exists(
-                        b_ + i_ * n_blocks, b + i * n_blocks))
-                    {
-                      const auto value =
-                        (residual1.block(b_)[i_] - residual0.block(b_)[i_]) /
-                        epsilon;
-
-                      if (std::abs(value) > tolerance)
-                        tangent_numeric.set(b_ + i_ * n_blocks,
-                                            b + i * n_blocks,
-                                            value);
-
-                      else if ((b == b_) && (i == i_))
-                        tangent_numeric.set(b_ + i_ * n_blocks,
-                                            b + i * n_blocks,
-                                            1.0);
-                    }
-                }
-        }
-  }
 
   template <int dim,
             typename Number,
@@ -104,7 +43,7 @@ namespace Test
     ConditionalOStream pcout(std::cout, is_zero_rank);
 
     // How to compute residual
-    const std::function<void(const VectorType &, VectorType &)> nl_residual =
+    auto nl_residual =
       [&](const auto &src, auto &dst) {
         if (enable_rbm)
           advection_operator.evaluate_forces(src);


### PR DESCRIPTION
When implementing a new operator, it would be nice to have an option just to code the RHS first and then immediately try to solve a demo problem using the jacobi free approach. For simplicity, one can use ILU, for instance, but in requires a tangent matrix still. So I added an option to provide such a matrix using finite differences.