### PR TITLE
Add option to treat first variable of the CH equation as the voids concentration

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/initial_values_array.h
+++ b/applications/sintering/include/pf-applications/sintering/initial_values_array.h
@@ -27,11 +27,13 @@ namespace Sintering
       const double             r0,
       const double             interface_width,
       const InterfaceDirection interface_direction = InterfaceDirection::middle,
-      const unsigned int       op_components_offset = 2,
-      const bool               is_accumulative      = false)
+      const unsigned int       op_components_offset  = 2,
+      const bool               concentration_as_void = false,
+      const bool               is_accumulative       = false)
       : InitialValuesSpherical<dim>(interface_width,
                                     interface_direction,
                                     op_components_offset,
+                                    concentration_as_void,
                                     is_accumulative)
       , r0(r0)
     {}

--- a/applications/sintering/include/pf-applications/sintering/initial_values_ch_ac.h
+++ b/applications/sintering/include/pf-applications/sintering/initial_values_ch_ac.h
@@ -28,7 +28,18 @@ namespace Sintering
   class InitialValuesCHAC : public InitialValues<dim>
   {
   public:
-    using InitialValues<dim>::InitialValues;
+    InitialValuesCHAC(
+      const double             interface_width,
+      const InterfaceDirection interface_direction = InterfaceDirection::middle,
+      const unsigned int       op_components_offset  = 2,
+      const bool               concentration_as_void = false,
+      const bool               is_accumulative       = false)
+      : InitialValues<dim>(interface_width,
+                           interface_direction,
+                           op_components_offset,
+                           is_accumulative)
+      , concentration_as_void(concentration_as_void)
+    {}
 
   protected:
     double
@@ -59,6 +70,9 @@ namespace Sintering
               ret_val =
                 *std::max_element(all_op_values.begin(), all_op_values.end());
             }
+
+          if (concentration_as_void)
+            ret_val = 1.0 - ret_val;
         }
       // Chemical potential of the CH equation
       else if (component == (this->op_components_offset - 1))
@@ -79,5 +93,9 @@ namespace Sintering
 
     virtual double
     op_value(const Point<dim> &p, const unsigned int order_parameter) const = 0;
+
+  private:
+    // Treat concentration term as a void param
+    const bool concentration_as_void;
   };
 } // namespace Sintering

--- a/applications/sintering/include/pf-applications/sintering/initial_values_circle.h
+++ b/applications/sintering/include/pf-applications/sintering/initial_values_circle.h
@@ -29,12 +29,14 @@ namespace Sintering
       const unsigned int       n_grains,
       const bool               minimize_order_parameters,
       const InterfaceDirection interface_direction = InterfaceDirection::middle,
-      const unsigned int       op_components_offset = 2,
-      const bool               is_accumulative      = false)
+      const unsigned int       op_components_offset  = 2,
+      const bool               concentration_as_void = false,
+      const bool               is_accumulative       = false)
       : InitialValuesArray<dim>(r0,
                                 interface_width,
                                 interface_direction,
                                 op_components_offset,
+                                concentration_as_void,
                                 is_accumulative)
     {
       const double alfa = 2 * M_PI / n_grains;

--- a/applications/sintering/include/pf-applications/sintering/initial_values_cloud.h
+++ b/applications/sintering/include/pf-applications/sintering/initial_values_cloud.h
@@ -37,11 +37,13 @@ namespace Sintering
       const double                      interface_buffer_ratio = 0.5,
       const double                      radius_buffer_ratio    = 0.0,
       const InterfaceDirection interface_direction = InterfaceDirection::middle,
-      const unsigned int       op_components_offset = 2,
-      const bool               is_accumulative      = false)
+      const unsigned int       op_components_offset  = 2,
+      const bool               concentration_as_void = false,
+      const bool               is_accumulative       = false)
       : InitialValuesSpherical<dim>(interface_width,
                                     interface_direction,
                                     op_components_offset,
+                                    concentration_as_void,
                                     is_accumulative)
       , particles(particles_in)
       , interface_width(interface_width)

--- a/applications/sintering/include/pf-applications/sintering/initial_values_hypercube.h
+++ b/applications/sintering/include/pf-applications/sintering/initial_values_hypercube.h
@@ -29,12 +29,14 @@ namespace Sintering
       const std::array<unsigned int, dim> &n_grains,
       const unsigned int                   n_order_parameters,
       const InterfaceDirection interface_direction = InterfaceDirection::middle,
-      const unsigned int       op_components_offset = 2,
-      const bool               is_accumulative      = false)
+      const unsigned int       op_components_offset  = 2,
+      const bool               concentration_as_void = false,
+      const bool               is_accumulative       = false)
       : InitialValuesArray<dim>(r0,
                                 interface_width,
                                 interface_direction,
                                 op_components_offset,
+                                concentration_as_void,
                                 is_accumulative)
     {
       unsigned int counter = 0;

--- a/applications/sintering/include/pf-applications/sintering/initial_values_microstructure.h
+++ b/applications/sintering/include/pf-applications/sintering/initial_values_microstructure.h
@@ -239,11 +239,13 @@ namespace Sintering
     InitialValuesMicrostructure(
       const double             interface_width     = 0.,
       const InterfaceDirection interface_direction = InterfaceDirection::middle,
-      const unsigned int       op_components_offset = 2,
-      const bool               is_accumulative      = false)
+      const unsigned int       op_components_offset  = 2,
+      const bool               concentration_as_void = false,
+      const bool               is_accumulative       = false)
       : InitialValuesCHAC<2>(interface_width,
                              interface_direction,
                              op_components_offset,
+                             concentration_as_void,
                              is_accumulative)
       , ref_h(interface_direction == InterfaceDirection::middle ?
                 interface_width / 2. :

--- a/applications/sintering/include/pf-applications/sintering/initial_values_microstructure_imaging.h
+++ b/applications/sintering/include/pf-applications/sintering/initial_values_microstructure_imaging.h
@@ -46,11 +46,13 @@ namespace Sintering
       std::istream &           stream,
       const double             interface_width     = 0.,
       const InterfaceDirection interface_direction = InterfaceDirection::middle,
-      const unsigned int       op_components_offset = 2,
-      const bool               is_accumulative      = false)
+      const unsigned int       op_components_offset  = 2,
+      const bool               concentration_as_void = false,
+      const bool               is_accumulative       = false)
       : InitialValuesMicrostructure(interface_width,
                                     interface_direction,
                                     op_components_offset,
+                                    concentration_as_void,
                                     is_accumulative)
     {
       unsigned int row_counter = 0;

--- a/applications/sintering/include/pf-applications/sintering/initial_values_microstructure_voronoi.h
+++ b/applications/sintering/include/pf-applications/sintering/initial_values_microstructure_voronoi.h
@@ -37,11 +37,13 @@ namespace Sintering
       std::istream &           stream,
       const double             interface_width     = 0.,
       const InterfaceDirection interface_direction = InterfaceDirection::middle,
-      const unsigned int       op_components_offset = 2,
-      const bool               is_accumulative      = false)
+      const unsigned int       op_components_offset  = 2,
+      const bool               concentration_as_void = false,
+      const bool               is_accumulative       = false)
       : InitialValuesMicrostructure(interface_width,
                                     interface_direction,
                                     op_components_offset,
+                                    concentration_as_void,
                                     is_accumulative)
     {
       constexpr unsigned int dim = 2;

--- a/applications/sintering/include/pf-applications/sintering/initial_values_spherical.h
+++ b/applications/sintering/include/pf-applications/sintering/initial_values_spherical.h
@@ -31,11 +31,13 @@ namespace Sintering
     InitialValuesSpherical(
       const double             interface_width,
       const InterfaceDirection interface_direction = InterfaceDirection::middle,
-      const unsigned int       op_components_offset = 2,
-      const bool               is_accumulative      = false)
+      const unsigned int       op_components_offset  = 2,
+      const bool               concentration_as_void = false,
+      const bool               is_accumulative       = false)
       : InitialValuesCHAC<dim>(interface_width,
                                interface_direction,
                                op_components_offset,
+                               concentration_as_void,
                                is_accumulative)
       , interface_offset(interface_direction == InterfaceDirection::inside ?
                            (-interface_width / 2.) :

--- a/applications/sintering/include/pf-applications/sintering/runner.h
+++ b/applications/sintering/include/pf-applications/sintering/runner.h
@@ -127,6 +127,7 @@ namespace Sintering
     const std::string  mode(argv[1]);
     const unsigned int op_components_offset =
       FreeEnergy<VectorizedArrayType>::op_components_offset;
+    const bool concentration_as_void = false;
 
     if (argc == 1 || mode == "--help")
       {
@@ -163,7 +164,8 @@ namespace Sintering
             n_grains,
             params.geometry_data.minimize_order_parameters,
             interface_direction,
-            op_components_offset);
+            op_components_offset,
+            concentration_as_void);
 
         AssertThrow(initial_solution->n_order_parameters() <=
                       MAX_SINTERING_GRAINS,
@@ -225,7 +227,8 @@ namespace Sintering
             n_grains,
             n_order_params_to_use,
             interface_direction,
-            op_components_offset);
+            op_components_offset,
+            concentration_as_void);
 
         AssertThrow(initial_solution->n_order_parameters() <=
                       MAX_SINTERING_GRAINS,
@@ -271,7 +274,8 @@ namespace Sintering
             params.geometry_data.interface_buffer_ratio,
             params.geometry_data.radius_buffer_ratio,
             interface_direction,
-            op_components_offset);
+            op_components_offset,
+            concentration_as_void);
 
         AssertThrow(initial_solution->n_order_parameters() <=
                       MAX_SINTERING_GRAINS,
@@ -310,14 +314,16 @@ namespace Sintering
                   fstream,
                   params.geometry_data.interface_width,
                   interface_direction,
-                  op_components_offset);
+                  op_components_offset,
+                  concentration_as_void);
             else if (mode == "--imaging")
               initial_solution =
                 std::make_shared<Sintering::InitialValuesMicrostructureImaging>(
                   fstream,
                   params.geometry_data.interface_width,
                   interface_direction,
-                  op_components_offset);
+                  op_components_offset,
+                  concentration_as_void);
             else
               AssertThrow(false, ExcNotImplemented());
 


### PR DESCRIPTION
This is required for grand potential phase-field models.