### PR TITLE
Attempt to recover grains inconsistency detect during grain tracking

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/driver.h
+++ b/applications/sintering/include/pf-applications/sintering/driver.h
@@ -2577,10 +2577,12 @@ namespace Sintering
                           }
                       }
 
-                    // If advection is enabled or we force the solver to attempt
-                    // to recover from the inconsistency exception, then execute
-                    // grain tracker
+                    // If advection is enabled or certain boundary conditions
+                    // are imposed or we force the solver to attempt to recover
+                    // from the inconsistency exception, then execute the grain
+                    // tracker.
                     if (params.advection_data.enable ||
+                        grain_tracker_required_for_ebc ||
                         params.grain_tracker_data.check_inconsistency)
                       do_grain_tracker = true;
                     // If mesh quality control is enabled and grain tracker is
@@ -2602,11 +2604,14 @@ namespace Sintering
                         run_grain_tracker(t, /*do_initialize = */ false);
                         n_timestep_last_gt = n_timestep_new;
 
-                        // If the mesh is to be executed at the beginning of the
-                        // next step, then we still need to run the grain
-                        // tracker once again if advection is enabled, otherwise
-                        // there is no need to
-                        if (do_mesh_refinement && params.advection_data.enable)
+                        // If the mesh refinement is to be executed at the
+                        // beginning of the next step, then we still need to run
+                        // the grain tracker once again if advection is enabled
+                        // or this is required for certain EBC, otherwise there
+                        // is no need to do that again.
+                        if (do_mesh_refinement &&
+                            (params.advection_data.enable ||
+                             grain_tracker_required_for_ebc))
                           do_grain_tracker = true;
                         else
                           do_grain_tracker = false;

--- a/applications/sintering/include/pf-applications/sintering/driver.h
+++ b/applications/sintering/include/pf-applications/sintering/driver.h
@@ -2750,6 +2750,10 @@ namespace Sintering
               {
                 process_failure(e.message(), "courant_violated");
               }
+            catch (const GrainTracker::ExcGrainsInconsistency &e)
+              {
+                process_failure(e.what(), "grains_inconsistency");
+              }
 
             if (has_converged)
               {

--- a/applications/sintering/include/pf-applications/sintering/parameters.h
+++ b/applications/sintering/include/pf-applications/sintering/parameters.h
@@ -633,6 +633,9 @@ namespace Sintering
       prm.add_parameter("UseOldRemap",
                         grain_tracker_data.use_old_remap,
                         "Use old remapping algo.");
+      prm.add_parameter("CheckInconsistency",
+                        grain_tracker_data.check_inconsistency,
+                        "Check grains inconsistency at the end of timestep.");
       prm.add_parameter("GrainRepresentation",
                         grain_tracker_data.grain_representation,
                         "Grain representation",

--- a/applications/sintering/include/pf-applications/sintering/parameters.h
+++ b/applications/sintering/include/pf-applications/sintering/parameters.h
@@ -633,6 +633,10 @@ namespace Sintering
       prm.add_parameter("UseOldRemap",
                         grain_tracker_data.use_old_remap,
                         "Use old remapping algo.");
+      prm.add_parameter("GrainRepresentation",
+                        grain_tracker_data.grain_representation,
+                        "Grain representation",
+                        Patterns::Selection("Spherical|Elliptical|Wavefront"));
       prm.leave_subsection();
 
 

--- a/applications/sintering/include/pf-applications/sintering/parameters.h
+++ b/applications/sintering/include/pf-applications/sintering/parameters.h
@@ -96,9 +96,10 @@ namespace Sintering
     unsigned int grain_tracker_frequency = 10; // 0 - no grain tracker
     unsigned int verbosity               = 0;
 
-    bool fast_reassignment  = false;
-    bool track_with_quality = false;
-    bool use_old_remap      = false;
+    bool fast_reassignment   = false;
+    bool track_with_quality  = false;
+    bool use_old_remap       = false;
+    bool check_inconsistency = false;
 
     std::string grain_representation = "Spherical";
   };
@@ -632,10 +633,6 @@ namespace Sintering
       prm.add_parameter("UseOldRemap",
                         grain_tracker_data.use_old_remap,
                         "Use old remapping algo.");
-      prm.add_parameter("GrainRepresentation",
-                        grain_tracker_data.grain_representation,
-                        "Grain representation",
-                        Patterns::Selection("Spherical|Elliptical|Wavefront"));
       prm.leave_subsection();
 
 


### PR DESCRIPTION
Currently if `GrainTracker::ExcGrainsInconsistency` is thrown somewhere during grain tracking, then the solver crashes. However, this is a recoverable scenario. Such an error simply means that we have made a too large timestep and we can attempt to perform a smaller one. Handling this required to modify a bit the logic of the time loop in the driver.