### PR TITLE
Refactor output

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/driver.h
+++ b/applications/sintering/include/pf-applications/sintering/driver.h
@@ -3140,14 +3140,14 @@ namespace Sintering
             for (unsigned int i = 0; i < sections.size(); ++i)
               {
                 auto proj_data_out = Postprocessors::build_default_output(
-                  sections[i].state.dof_handler,
+                  sections[i].state->dof_handler,
                   Postprocessors::BlockVectorWrapper<
-                    std::vector<Vector<Number>>>(sections[i].state.solution),
+                    std::vector<Vector<Number>>>(sections[i].state->solution),
                   names,
                   params.output_data.fields.count("subdomain"),
                   params.output_data.higher_order_cells);
 
-                if (sections[i].state.dof_handler.n_dofs() > 0)
+                if (sections[i].state->dof_handler.n_dofs() > 0)
                   proj_data_out.build_patches();
 
                 std::stringstream ss;

--- a/applications/sintering/include/pf-applications/sintering/output.h
+++ b/applications/sintering/include/pf-applications/sintering/output.h
@@ -144,11 +144,11 @@ namespace Sintering
                           << ")" << std::endl;
 
                     Postprocessors::output_grain_contours_projected_vtu(
-                      sections[i].state.mapping,
-                      sections[i].state.dof_handler,
+                      sections[i].state->mapping,
+                      sections[i].state->dof_handler,
                       Postprocessors::BlockVectorWrapper<
                         std::vector<Vector<Number>>>(
-                        sections[i].state.solution),
+                        sections[i].state->solution),
                       iso_value,
                       output,
                       n_op,
@@ -290,10 +290,10 @@ namespace Sintering
                       << std::endl;
 
                 Postprocessors::output_grain_contours_projected(
-                  sections[i].state.mapping,
-                  sections[i].state.dof_handler,
+                  sections[i].state->mapping,
+                  sections[i].state->dof_handler,
                   Postprocessors::BlockVectorWrapper<
-                    std::vector<Vector<Number>>>(sections[i].state.solution),
+                    std::vector<Vector<Number>>>(sections[i].state->solution),
                   iso_value,
                   output,
                   n_op,

--- a/applications/sintering/include/pf-applications/sintering/projection.h
+++ b/applications/sintering/include/pf-applications/sintering/projection.h
@@ -68,13 +68,21 @@ namespace Sintering
     template <int dim, typename Number>
     struct ProjectedData
     {
-      StateData<dim, Number> state;
-      Point<dim>             origin;
-      Point<dim>             normal;
+      std::unique_ptr<StateData<dim, Number>> state;
+      Point<dim + 1>                          origin;
+      Point<dim + 1>                          normal;
+
+      ProjectedData(std::unique_ptr<StateData<dim, Number>> state,
+                    const Point<dim + 1>                   &origin,
+                    const Point<dim + 1>                   &normal)
+        : state(std::move(state))
+        , origin(origin)
+        , normal(normal)
+      {}
     };
 
     template <typename VectorType, int dim = 3>
-    StateData<dim - 1, typename VectorType::value_type>
+    std::unique_ptr<StateData<dim - 1, typename VectorType::value_type>>
     build_projection(const DoFHandler<dim> &background_dof_handler,
                      const VectorType      &vector,
                      const unsigned int     direction                = 2,
@@ -135,8 +143,9 @@ namespace Sintering
         if (d != direction)
           projector.push_back(d);
 
-      StateData<dim - 1, typename VectorType::value_type> projection(
-        vector_to_be_used->n_blocks());
+      auto projection =
+        std::make_unique<StateData<dim - 1, typename VectorType::value_type>>(
+          vector_to_be_used->n_blocks());
 
       for (const auto &cell :
            background_dof_handler_to_be_used->active_cell_iterators())
@@ -149,12 +158,12 @@ namespace Sintering
               {
                 CellData<dim - 1> cell_data;
                 unsigned int      vertex_counter = 0;
-                unsigned int vertex_numerator = projection.solution[0].size();
+                unsigned int vertex_numerator = projection->solution[0].size();
 
                 for (unsigned int b = 0; b < vector_to_be_used->n_blocks(); ++b)
                   {
-                    projection.solution[b].grow_or_shrink(
-                      projection.solution[b].size() +
+                    projection->solution[b].grow_or_shrink(
+                      projection->solution[b].size() +
                       cell_data.vertices.size());
                   }
 
@@ -196,7 +205,8 @@ namespace Sintering
 
                             const auto val_proj = val0 + fac * (val0 - val1);
 
-                            projection.solution[b][vertex_numerator] = val_proj;
+                            projection->solution[b][vertex_numerator] =
+                              val_proj;
                           }
 
                         // Transfer graint tracker data to the projected grid
@@ -224,8 +234,8 @@ namespace Sintering
 
       if (vertices.size() > 0)
         {
-          projection.tria.create_triangulation(vertices, cells, subcelldata);
-          projection.dof_handler.distribute_dofs(projection.fe_dg);
+          projection->tria.create_triangulation(vertices, cells, subcelldata);
+          projection->dof_handler.distribute_dofs(projection->fe_dg);
         }
 
       if (has_ghost_elements == false)


### PR DESCRIPTION
The `output_result()` has grown to some enormous size, I simplified it a bit, mainly, pulling some advanced postprocessing functionality to a separate function.

I also added several `if constexpr` to limit certain parts of the code to 2D and/or 3D cases since I am planning to extend the code later to 1D cases.