### PR TITLE
Invert sign of the chemical potential equation

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/operator_sintering_generic.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_sintering_generic.h
@@ -135,13 +135,13 @@ namespace Sintering
 
 
       // 2) process mu row
-      value_result[1] = -value[1] + free_energy_eval.d2f_dc2() * value[0];
+      value_result[1] = value[1] - free_energy_eval.d2f_dc2() * value[0];
 
       for (unsigned int ig = 0; ig < n_grains; ++ig)
-        value_result[1] +=
+        value_result[1] -=
           free_energy_eval.d2f_dcdetai(lin_etas_value[ig]) * value[ig + 2];
 
-      gradient_result[1] = kappa_c * gradient[0];
+      gradient_result[1] = -kappa_c * gradient[0];
 
 
 
@@ -281,8 +281,8 @@ namespace Sintering
                                                   gradient[1]);
 
             // 2) process mu row
-            value_result[1]    = -value[1] + free_energy_eval.df_dc();
-            gradient_result[1] = kappa_c * gradient[0];
+            value_result[1]    = value[1] - free_energy_eval.df_dc();
+            gradient_result[1] = -kappa_c * gradient[0];
 
 
             // 3) process eta rows

--- a/applications/sintering/include/pf-applications/sintering/preconditioners.h
+++ b/applications/sintering/include/pf-applications/sintering/preconditioners.h
@@ -132,7 +132,7 @@ namespace Sintering
 
           // CH with all terms
           value_result[0] = phi.get_value(q)[0] * weight;
-          value_result[1] = -phi.get_value(q)[1] +
+          value_result[1] = phi.get_value(q)[1] -
                             free_energy_eval.d2f_dc2() * phi.get_value(q)[0];
 
           gradient_result[0] =
@@ -141,15 +141,15 @@ namespace Sintering
             mobility.dM_dc(c, etas, c_grad, etas_grad) * mu_grad *
               phi.get_value(q)[0] +
             mobility.dM_dgrad_c(c, c_grad, mu_grad) * phi.get_gradient(q)[0];
-          gradient_result[1] = kappa_c * phi.get_gradient(q)[0];
+          gradient_result[1] = -kappa_c * phi.get_gradient(q)[0];
 #else
           // CH with the terms as considered in BlockPreconditioner3CHData
           value_result[0] = phi.get_value(q)[0] * weight;
-          value_result[1] = -phi.get_value(q)[1];
+          value_result[1] = phi.get_value(q)[1];
 
           gradient_result[0] = mobility.apply_M(
             c, etas, etas.size(), c_grad, etas_grad, phi.get_gradient(q)[1]);
-          gradient_result[1] = kappa_c * phi.get_gradient(q)[0];
+          gradient_result[1] = -kappa_c * phi.get_gradient(q)[0];
 #endif
 
           if (this->advection.enabled())

--- a/tests/residual_generic_scalar_no_rbm.mpirun=1.output
+++ b/tests/residual_generic_scalar_no_rbm.mpirun=1.output
@@ -6,7 +6,7 @@ Vector data:
 block 1: Process #0
 Local range: [0, 6), global size: 6
 Vector data:
--7.278e-02 -2.011e-01 -9.778e-02 -2.511e-01 -1.061e-01 -1.311e-01
+7.278e-02 2.011e-01 9.778e-02 2.511e-01 1.061e-01 1.311e-01
 block 2: Process #0
 Local range: [0, 6), global size: 6
 Vector data:

--- a/tests/residual_generic_scalar_no_rbm.mpirun=2.output
+++ b/tests/residual_generic_scalar_no_rbm.mpirun=2.output
@@ -6,7 +6,7 @@ Vector data:
 block 1: Process #0
 Local range: [0, 4), global size: 6
 Vector data:
--7.278e-02 -2.011e-01 -9.778e-02 -2.511e-01
+7.278e-02 2.011e-01 9.778e-02 2.511e-01
 block 2: Process #0
 Local range: [0, 4), global size: 6
 Vector data:
@@ -23,7 +23,7 @@ Vector data:
 block 1: Process #1
 Local range: [4, 6), global size: 6
 Vector data:
--1.061e-01 -1.311e-01
+1.061e-01 1.311e-01
 block 2: Process #1
 Local range: [4, 6), global size: 6
 Vector data:

--- a/tests/residual_generic_scalar_no_rbm.mpirun=3.output
+++ b/tests/residual_generic_scalar_no_rbm.mpirun=3.output
@@ -23,7 +23,7 @@ Vector data:
 block 1: Process #1
 Local range: [0, 4), global size: 6
 Vector data:
--7.278e-02 -2.011e-01 -9.778e-02 -2.511e-01
+7.278e-02 2.011e-01 9.778e-02 2.511e-01
 block 2: Process #1
 Local range: [0, 4), global size: 6
 Vector data:
@@ -40,7 +40,7 @@ Vector data:
 block 1: Process #2
 Local range: [4, 6), global size: 6
 Vector data:
--1.061e-01 -1.311e-01
+1.061e-01 1.311e-01
 block 2: Process #2
 Local range: [4, 6), global size: 6
 Vector data:

--- a/tests/residual_generic_scalar_rbm.mpirun=1.output
+++ b/tests/residual_generic_scalar_rbm.mpirun=1.output
@@ -6,7 +6,7 @@ Vector data:
 block 1: Process #0
 Local range: [0, 6), global size: 6
 Vector data:
--7.278e-02 -2.011e-01 -9.778e-02 -2.511e-01 -1.061e-01 -1.311e-01
+7.278e-02 2.011e-01 9.778e-02 2.511e-01 1.061e-01 1.311e-01
 block 2: Process #0
 Local range: [0, 6), global size: 6
 Vector data:

--- a/tests/residual_generic_scalar_rbm.mpirun=2.output
+++ b/tests/residual_generic_scalar_rbm.mpirun=2.output
@@ -6,7 +6,7 @@ Vector data:
 block 1: Process #0
 Local range: [0, 4), global size: 6
 Vector data:
--7.278e-02 -2.011e-01 -9.778e-02 -2.511e-01
+7.278e-02 2.011e-01 9.778e-02 2.511e-01
 block 2: Process #0
 Local range: [0, 4), global size: 6
 Vector data:
@@ -23,7 +23,7 @@ Vector data:
 block 1: Process #1
 Local range: [4, 6), global size: 6
 Vector data:
--1.061e-01 -1.311e-01
+1.061e-01 1.311e-01
 block 2: Process #1
 Local range: [4, 6), global size: 6
 Vector data:

--- a/tests/residual_generic_scalar_rbm.mpirun=3.output
+++ b/tests/residual_generic_scalar_rbm.mpirun=3.output
@@ -23,7 +23,7 @@ Vector data:
 block 1: Process #1
 Local range: [0, 4), global size: 6
 Vector data:
--7.278e-02 -2.011e-01 -9.778e-02 -2.511e-01
+7.278e-02 2.011e-01 9.778e-02 2.511e-01
 block 2: Process #1
 Local range: [0, 4), global size: 6
 Vector data:
@@ -40,7 +40,7 @@ Vector data:
 block 1: Process #2
 Local range: [4, 6), global size: 6
 Vector data:
--1.061e-01 -1.311e-01
+1.061e-01 1.311e-01
 block 2: Process #2
 Local range: [4, 6), global size: 6
 Vector data:

--- a/tests/residual_generic_tensorial_no_rbm.mpirun=1.output
+++ b/tests/residual_generic_tensorial_no_rbm.mpirun=1.output
@@ -6,7 +6,7 @@ Vector data:
 block 1: Process #0
 Local range: [0, 6), global size: 6
 Vector data:
--7.278e-02 -2.011e-01 -9.778e-02 -2.511e-01 -1.061e-01 -1.311e-01
+7.278e-02 2.011e-01 9.778e-02 2.511e-01 1.061e-01 1.311e-01
 block 2: Process #0
 Local range: [0, 6), global size: 6
 Vector data:

--- a/tests/residual_generic_tensorial_no_rbm.mpirun=2.output
+++ b/tests/residual_generic_tensorial_no_rbm.mpirun=2.output
@@ -6,7 +6,7 @@ Vector data:
 block 1: Process #0
 Local range: [0, 4), global size: 6
 Vector data:
--7.278e-02 -2.011e-01 -9.778e-02 -2.511e-01
+7.278e-02 2.011e-01 9.778e-02 2.511e-01
 block 2: Process #0
 Local range: [0, 4), global size: 6
 Vector data:
@@ -23,7 +23,7 @@ Vector data:
 block 1: Process #1
 Local range: [4, 6), global size: 6
 Vector data:
--1.061e-01 -1.311e-01
+1.061e-01 1.311e-01
 block 2: Process #1
 Local range: [4, 6), global size: 6
 Vector data:

--- a/tests/residual_generic_tensorial_no_rbm.mpirun=3.output
+++ b/tests/residual_generic_tensorial_no_rbm.mpirun=3.output
@@ -23,7 +23,7 @@ Vector data:
 block 1: Process #1
 Local range: [0, 4), global size: 6
 Vector data:
--7.278e-02 -2.011e-01 -9.778e-02 -2.511e-01
+7.278e-02 2.011e-01 9.778e-02 2.511e-01
 block 2: Process #1
 Local range: [0, 4), global size: 6
 Vector data:
@@ -40,7 +40,7 @@ Vector data:
 block 1: Process #2
 Local range: [4, 6), global size: 6
 Vector data:
--1.061e-01 -1.311e-01
+1.061e-01 1.311e-01
 block 2: Process #2
 Local range: [4, 6), global size: 6
 Vector data:

--- a/tests/residual_generic_tensorial_rbm.mpirun=1.output
+++ b/tests/residual_generic_tensorial_rbm.mpirun=1.output
@@ -6,7 +6,7 @@ Vector data:
 block 1: Process #0
 Local range: [0, 6), global size: 6
 Vector data:
--7.278e-02 -2.011e-01 -9.778e-02 -2.511e-01 -1.061e-01 -1.311e-01
+7.278e-02 2.011e-01 9.778e-02 2.511e-01 1.061e-01 1.311e-01
 block 2: Process #0
 Local range: [0, 6), global size: 6
 Vector data:

--- a/tests/residual_generic_tensorial_rbm.mpirun=2.output
+++ b/tests/residual_generic_tensorial_rbm.mpirun=2.output
@@ -6,7 +6,7 @@ Vector data:
 block 1: Process #0
 Local range: [0, 4), global size: 6
 Vector data:
--7.278e-02 -2.011e-01 -9.778e-02 -2.511e-01
+7.278e-02 2.011e-01 9.778e-02 2.511e-01
 block 2: Process #0
 Local range: [0, 4), global size: 6
 Vector data:
@@ -23,7 +23,7 @@ Vector data:
 block 1: Process #1
 Local range: [4, 6), global size: 6
 Vector data:
--1.061e-01 -1.311e-01
+1.061e-01 1.311e-01
 block 2: Process #1
 Local range: [4, 6), global size: 6
 Vector data:

--- a/tests/residual_generic_tensorial_rbm.mpirun=3.output
+++ b/tests/residual_generic_tensorial_rbm.mpirun=3.output
@@ -23,7 +23,7 @@ Vector data:
 block 1: Process #1
 Local range: [0, 4), global size: 6
 Vector data:
--7.278e-02 -2.011e-01 -9.778e-02 -2.511e-01
+7.278e-02 2.011e-01 9.778e-02 2.511e-01
 block 2: Process #1
 Local range: [0, 4), global size: 6
 Vector data:
@@ -40,7 +40,7 @@ Vector data:
 block 1: Process #2
 Local range: [4, 6), global size: 6
 Vector data:
--1.061e-01 -1.311e-01
+1.061e-01 1.311e-01
 block 2: Process #2
 Local range: [4, 6), global size: 6
 Vector data:


### PR DESCRIPTION
Previously the equation for chemical potential was written such that the primary variable itself had a negative sign. This is not very convenient for generalization of various time stepping strategies to be implemented (implicit and explicit). I inverted the sign. Now the primary unknowns of both time-dependent and algebraic equations enter with positive signs.