### PR TITLE
Add equation type knowledge to the operator

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/operator_base.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_base.h
@@ -39,8 +39,8 @@ namespace Sintering
   enum class EquationType
   {
     Undefined,
-    TimePDE,
-    Algebraic
+    TimeDependent,
+    Stationary
   };
 
   template <int dim, typename Number, typename VectorizedArrayType, typename T>

--- a/applications/sintering/include/pf-applications/sintering/operator_grain_growth.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_grain_growth.h
@@ -502,7 +502,7 @@ namespace Sintering
     equation_type(const unsigned int component) const override
     {
       (void)component;
-      return EquationType::TimePDE;
+      return EquationType::TimeDependent;
     }
 
     static constexpr unsigned int

--- a/applications/sintering/include/pf-applications/sintering/operator_grand_potential_greenquist.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_grand_potential_greenquist.h
@@ -803,7 +803,7 @@ namespace Sintering
     equation_type(const unsigned int component) const override
     {
       (void)component;
-      return EquationType::TimePDE;
+      return EquationType::TimeDependent;
     }
 
     template <int with_time_derivative = 2>

--- a/applications/sintering/include/pf-applications/sintering/operator_postproc.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_postproc.h
@@ -105,7 +105,7 @@ namespace Sintering
     equation_type(const unsigned int component) const override
     {
       (void)component;
-      return EquationType::Algebraic;
+      return EquationType::Stationary;
     }
 
     template <int n_comp, int n_grains, typename FECellIntegratorType>

--- a/applications/sintering/include/pf-applications/sintering/operator_sintering_generic.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_sintering_generic.h
@@ -634,7 +634,8 @@ namespace Sintering
     virtual EquationType
     equation_type(const unsigned int component) const override
     {
-      return component != 1 ? EquationType::TimePDE : EquationType::Algebraic;
+      return component != 1 ? EquationType::TimeDependent :
+                              EquationType::Stationary;
     }
 
     template <int n_comp, int n_grains, int fe_degree, int n_q_points>


### PR DESCRIPTION
Since time-dependent and algebraic equations should be treated a bit differently in the explicit time schemes, a particular operator is now responsible for providing this information.