### PR TITLE
Encapsulate dts

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/operator_sintering_data.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_sintering_data.h
@@ -22,6 +22,7 @@
 namespace Sintering
 {
   using namespace dealii;
+  using namespace TimeIntegration;
 
   template <int dim, typename VectorizedArrayType>
   struct SinteringOperatorData
@@ -44,11 +45,11 @@ namespace Sintering
     SinteringOperatorData(const Number                      kappa_c,
                           const Number                      kappa_p,
                           std::shared_ptr<MobilityProvider> mobility_provider,
-                          const unsigned int                integration_order,
+                          TimeIntegratorData<Number>      &&time_data_in,
                           const unsigned int op_components_offset = 2)
       : kappa_c(kappa_c)
       , kappa_p(kappa_p)
-      , time_data(integration_order)
+      , time_data(std::move(time_data_in))
       , mobility(mobility_provider)
       , op_components_offset(op_components_offset)
       , t(0.0)
@@ -57,7 +58,7 @@ namespace Sintering
     const Number kappa_c;
     const Number kappa_p;
 
-    TimeIntegration::TimeIntegratorData<Number> time_data;
+    TimeIntegratorData<Number> time_data;
 
   public:
     const Table<3, VectorizedArrayType> &

--- a/applications/sintering/sintering_throughput.cc
+++ b/applications/sintering/sintering_throughput.cc
@@ -60,6 +60,7 @@ static_assert(false, "No grains number has been given!");
 
 using namespace dealii;
 using namespace Sintering;
+using namespace TimeIntegration;
 
 template <typename T, typename VectorType>
 using evaluate_nonlinear_residual_t =
@@ -109,22 +110,20 @@ main(int argc, char **argv)
   constexpr bool test_sintering_wang    = true & scalar_mobility;
 
   // some arbitrary constants
-  const double        A                      = 16;
-  const double        B                      = 1;
-  const double        kappa_c                = 1;
-  const double        kappa_p                = 0.5;
-  const double        Mvol                   = 1e-2;
-  const double        Mvap                   = 1e-10;
-  const double        Msurf                  = 4;
-  const double        Mgb                    = 0.4;
-  const double        L                      = 1;
-  const double        time_integration_order = 1;
-  const double        mt                     = 1.0;
-  const double        mr                     = 1.0;
-  const double        t                      = 0.0;
-  const double        dt                     = 0.1;
-  std::vector<double> dts(time_integration_order, 0.0);
-  dts[0] = dt;
+  const double A                      = 16;
+  const double B                      = 1;
+  const double kappa_c                = 1;
+  const double kappa_p                = 0.5;
+  const double Mvol                   = 1e-2;
+  const double Mvap                   = 1e-10;
+  const double Msurf                  = 4;
+  const double Mgb                    = 0.4;
+  const double L                      = 1;
+  const double time_integration_order = 1;
+  const double mt                     = 1.0;
+  const double mr                     = 1.0;
+  const double t                      = 0.0;
+  const double dt                     = 0.1;
 
   const std::string fe_type =
 #ifdef USE_FE_Q_iso_Q1
@@ -272,16 +271,17 @@ main(int argc, char **argv)
               const std::shared_ptr<MobilityProvider> mobility_provider =
                 std::make_shared<ProviderAbstract>(Mvol, Mvap, Msurf, Mgb, L);
 
-              TimeIntegration::SolutionHistory<BlockVectorType>
-                solution_history(time_integration_order + 1);
+              SolutionHistory<BlockVectorType> solution_history(
+                time_integration_order + 1);
 
               FreeEnergy<VectorizedArrayType> free_energy(A, B);
 
+              TimeIntegratorData<Number> time_data(time_integration_order, dt);
+
               SinteringOperatorData<dim, VectorizedArrayType> sintering_data(
-                kappa_c, kappa_p, mobility_provider, time_integration_order);
+                kappa_c, kappa_p, mobility_provider, std::move(time_data));
 
               sintering_data.set_n_components(n_components);
-              sintering_data.time_data.set_all_dt(dts);
               sintering_data.set_time(t);
 
               AdvectionMechanism<dim, Number, VectorizedArrayType>
@@ -322,16 +322,17 @@ main(int argc, char **argv)
               const std::shared_ptr<MobilityProvider> mobility_provider =
                 std::make_shared<ProviderAbstract>(Mvol, Mvap, Msurf, Mgb, L);
 
-              TimeIntegration::SolutionHistory<BlockVectorType>
-                solution_history(time_integration_order + 1);
+              SolutionHistory<BlockVectorType> solution_history(
+                time_integration_order + 1);
 
               FreeEnergy<VectorizedArrayType> free_energy(A, B);
 
+              TimeIntegratorData<Number> time_data(time_integration_order, dt);
+
               SinteringOperatorData<dim, VectorizedArrayType> sintering_data(
-                kappa_c, kappa_p, mobility_provider, time_integration_order);
+                kappa_c, kappa_p, mobility_provider, std::move(time_data));
 
               sintering_data.set_n_components(n_components);
-              sintering_data.time_data.set_all_dt(dts);
               sintering_data.set_time(t);
 
               const unsigned int n_grains = n_components - 2;

--- a/benchmarks/layer_wise.likwid.cc
+++ b/benchmarks/layer_wise.likwid.cc
@@ -58,6 +58,7 @@ static unsigned int likwid_counter = 0;
 
 using namespace dealii;
 using namespace Sintering;
+using namespace TimeIntegration;
 
 struct Parameters
 {
@@ -432,31 +433,30 @@ test(const Parameters &params, ConvergenceTable &table)
 
       HelmholtzQOperator q_point_operator_h;
 
-      const double        A                      = 16;
-      const double        B                      = 1;
-      const double        kappa_c                = 1;
-      const double        kappa_p                = 0.5;
-      const double        Mvol                   = 1e-2;
-      const double        Mvap                   = 1e-10;
-      const double        Msurf                  = 4;
-      const double        Mgb                    = 0.4;
-      const double        L                      = 1;
-      const double        time_integration_order = 1;
-      const double        t                      = 0.0;
-      const double        dt                     = 0.1;
-      std::vector<double> dts(time_integration_order, 0.0);
-      dts[0] = dt;
+      const double A                      = 16;
+      const double B                      = 1;
+      const double kappa_c                = 1;
+      const double kappa_p                = 0.5;
+      const double Mvol                   = 1e-2;
+      const double Mvap                   = 1e-10;
+      const double Msurf                  = 4;
+      const double Mgb                    = 0.4;
+      const double L                      = 1;
+      const double time_integration_order = 1;
+      const double t                      = 0.0;
+      const double dt                     = 0.1;
 
       const std::shared_ptr<MobilityProvider> mobility_provider =
         std::make_shared<ProviderAbstract>(Mvol, Mvap, Msurf, Mgb, L);
 
       FreeEnergy<VectorizedArrayType> free_energy(A, B);
 
+      TimeIntegratorData<Number> time_data(time_integration_order, dt);
+
       SinteringOperatorData<dim, VectorizedArrayType> sintering_data(
-        kappa_c, kappa_p, mobility_provider, time_integration_order);
+        kappa_c, kappa_p, mobility_provider, std::move(time_data));
 
       sintering_data.set_n_components(n_components);
-      sintering_data.time_data.set_all_dt(dts);
       sintering_data.set_time(t);
 
       AlignedVector<VectorizedArrayType> buffer;

--- a/include/pf-applications/time_integration/time_integrators.h
+++ b/include/pf-applications/time_integration/time_integrators.h
@@ -34,11 +34,38 @@ namespace TimeIntegration
   class TimeIntegratorData
   {
   public:
+    TimeIntegratorData()
+      : order(0)
+    {}
+
     TimeIntegratorData(unsigned int order)
       : order(order)
       , dt(order)
       , weights(order + 1)
     {}
+
+    TimeIntegratorData(unsigned int order, Number dt_init)
+      : TimeIntegratorData(order)
+    {
+      update_dt(dt_init);
+    }
+
+    TimeIntegratorData(const TimeIntegratorData &other, unsigned int order)
+      : TimeIntegratorData(order)
+    {
+      for (unsigned int i = 0; i < std::min(order, other.order); ++i)
+        dt[i] = other.dt[i];
+
+      update_weights();
+    }
+
+    void
+    replace_dt(Number dt_new)
+    {
+      dt[0] = dt_new;
+
+      update_weights();
+    }
 
     void
     update_dt(Number dt_new)
@@ -126,7 +153,6 @@ namespace TimeIntegration
 
     BOOST_SERIALIZATION_SPLIT_MEMBER()
 
-  private:
     unsigned int
     effective_order() const
     {
@@ -135,6 +161,7 @@ namespace TimeIntegration
       });
     }
 
+  private:
     void
     update_weights()
     {

--- a/include/pf-applications/time_integration/time_integrators.h
+++ b/include/pf-applications/time_integration/time_integrators.h
@@ -102,6 +102,30 @@ namespace TimeIntegration
       return order;
     }
 
+    /* Serialization */
+    template <class Archive>
+    void
+    save(Archive &ar, const unsigned int /*version*/) const
+    {
+      ar &order;
+      ar &boost::serialization::make_array(dt.data(), dt.size());
+    }
+
+    template <class Archive>
+    void
+    load(Archive &ar, const unsigned int /*version*/)
+    {
+      ar &order;
+      dt.resize(order);
+      weights.resize(order + 1);
+
+      ar &boost::serialization::make_array(dt.data(), dt.size());
+
+      update_weights();
+    }
+
+    BOOST_SERIALIZATION_SPLIT_MEMBER()
+
   private:
     unsigned int
     effective_order() const

--- a/tests/advection_mechanism_data.cc
+++ b/tests/advection_mechanism_data.cc
@@ -21,6 +21,7 @@
 
 using namespace dealii;
 using namespace Sintering;
+using namespace TimeIntegration;
 
 int
 main(int argc, char **argv)
@@ -71,8 +72,10 @@ main(int argc, char **argv)
   const std::shared_ptr<MobilityProvider> mobility_provider =
     std::make_shared<ProviderAbstract>(Mvol, Mvap, Msurf, Mgb, L);
 
+  TimeIntegratorData<Number> time_data(time_integration_order);
+
   SinteringOperatorData<dim, VectorizedArrayType> sintering_data(
-    kappa_c, kappa_p, mobility_provider, time_integration_order);
+    kappa_c, kappa_p, mobility_provider, std::move(time_data));
 
   const unsigned int n_grains     = 3;
   const unsigned int n_components = n_grains + 2;

--- a/tests/include/pf-applications/tests/sintering_model.h
+++ b/tests/include/pf-applications/tests/sintering_model.h
@@ -15,6 +15,8 @@
 #include <pf-applications/grain_tracker/tracker.h>
 #include <pf-applications/matrix_free/tools.h>
 #include <pf-applications/structural/material.h>
+#include <pf-applications/time_integration/solution_history.h>
+#include <pf-applications/time_integration/time_integrators.h>
 
 #include <iostream>
 
@@ -22,6 +24,7 @@ namespace Test
 {
   using namespace dealii;
   using namespace Sintering;
+  using namespace TimeIntegration;
 
   template <int dim,
             typename Number,
@@ -47,7 +50,8 @@ namespace Test
           /*kappa_c=*/0.1,
           /*kappa_p=*/0.1,
           std::make_shared<ProviderAbstract>(1e-1, 1e-8, 1e1, 1e0, 1e1),
-          time_integration_order)
+          TimeIntegratorData<Number>(time_integration_order,
+                                     /*dt=*/1e-5))
       , advection_mechanism(enable_rbm,
                             /*mt=*/1.0,
                             /*mr=*/1.0)
@@ -190,9 +194,6 @@ namespace Test
         }
 
       solution_history.set_recent_old_solution(solution);
-      std::vector<Number> dts(time_integration_order);
-      dts[0] = 1e-5;
-      sintering_data.time_data.set_all_dt(dts);
 
       const double k           = 25;
       const double cgb         = 0;
@@ -269,7 +270,7 @@ namespace Test
     QGauss<dim>                                          quad;
     DoFHandler<dim>                                      dof_handler;
     AffineConstraints<Number>                            constraints;
-    TimeIntegration::SolutionHistory<VectorType>         solution_history;
+    SolutionHistory<VectorType>                          solution_history;
     FreeEnergy                                           free_energy;
     SinteringOperatorData<dim, VectorizedArrayType>      sintering_data;
     MatrixFree<dim, Number, VectorizedArrayType>         matrix_free;

--- a/tests/microstructure_from_imaging.cc
+++ b/tests/microstructure_from_imaging.cc
@@ -17,10 +17,8 @@
 
 #include <pf-applications/sintering/initial_values_microstructure_imaging.h>
 
+#include <pf-applications/tests/macro.h>
 #include <pf-applications/tests/microstructure_tester.h>
-
-#define STRING(x) #x
-#define XSTRING(x) STRING(x)
 
 using namespace Sintering;
 


### PR DESCRIPTION
The `dts` vector in driver was very confusing. I encapsulated it inside `TimeIntegratorData`, which is also now responsible for its serialization. I modified the tests and other executable accordingly.