### PR TITLE
Accumulate concentration at the grain boundaries for initial configurations

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/initial_values_ch_ac.h
+++ b/applications/sintering/include/pf-applications/sintering/initial_values_ch_ac.h
@@ -59,10 +59,7 @@ namespace Sintering
             {
               ret_val = std::accumulate(all_op_values.begin(),
                                         all_op_values.end(),
-                                        0,
-                                        [](auto a, auto b) {
-                                          return std::move(a) + b;
-                                        });
+                                        0.0);
               ret_val = std::min(1.0, ret_val);
             }
           else

--- a/applications/sintering/include/pf-applications/sintering/parameters.h
+++ b/applications/sintering/include/pf-applications/sintering/parameters.h
@@ -66,6 +66,7 @@ namespace Sintering
     unsigned int    max_prime                          = 20;
     std::string     global_refinement                  = "None";
     std::string     initial_mesh                       = "Interface";
+    bool            accumulative                       = false;
     double          max_level0_divisions_per_interface = 1.0 - 1e-9;
     BoundingBoxData bounding_box_data;
     DivisionsData   divisions_data;
@@ -482,6 +483,9 @@ namespace Sintering
       prm.add_parameter("MaxLevel0DivisionsPerInterface",
                         geometry_data.max_level0_divisions_per_interface,
                         "Maximum initial number of divisions per interface.");
+      prm.add_parameter("Accumulative",
+                        geometry_data.accumulative,
+                        "Is initial concentration accumulative at the GBs.");
 
       prm.enter_subsection("BoundingBox");
       prm.add_parameter("Xmin",

--- a/applications/sintering/include/pf-applications/sintering/runner.h
+++ b/applications/sintering/include/pf-applications/sintering/runner.h
@@ -119,7 +119,8 @@ namespace Sintering
             params.geometry_data.minimize_order_parameters,
             interface_direction,
             op_components_offset,
-            concentration_as_void);
+            concentration_as_void,
+            params.geometry_data.accumulative);
 
         AssertThrow(initial_solution->n_order_parameters() <=
                       MAX_SINTERING_GRAINS,
@@ -182,7 +183,8 @@ namespace Sintering
             n_order_params_to_use,
             interface_direction,
             op_components_offset,
-            concentration_as_void);
+            concentration_as_void,
+            params.geometry_data.accumulative);
 
         AssertThrow(initial_solution->n_order_parameters() <=
                       MAX_SINTERING_GRAINS,
@@ -229,7 +231,8 @@ namespace Sintering
             params.geometry_data.radius_buffer_ratio,
             interface_direction,
             op_components_offset,
-            concentration_as_void);
+            concentration_as_void,
+            params.geometry_data.accumulative);
 
         AssertThrow(initial_solution->n_order_parameters() <=
                       MAX_SINTERING_GRAINS,
@@ -269,7 +272,8 @@ namespace Sintering
                   params.geometry_data.interface_width,
                   interface_direction,
                   op_components_offset,
-                  concentration_as_void);
+                  concentration_as_void,
+                  params.geometry_data.accumulative);
             else if (mode == "--imaging")
               initial_solution =
                 std::make_shared<Sintering::InitialValuesMicrostructureImaging>(
@@ -277,7 +281,8 @@ namespace Sintering
                   params.geometry_data.interface_width,
                   interface_direction,
                   op_components_offset,
-                  concentration_as_void);
+                  concentration_as_void,
+                  params.geometry_data.accumulative);
             else
               AssertThrow(false, ExcNotImplemented());
 


### PR DESCRIPTION
There has always been an option to set up the accumulative grain boundaries definition at the initial configuration for the atomic concentration. Now I made it available for config files.