### PR TITLE
Customize FE_DEGREE outside of the runner

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/runner.h
+++ b/applications/sintering/include/pf-applications/sintering/runner.h
@@ -24,10 +24,13 @@ static_assert(false, "No grains number has been given!");
 // #define USE_FE_Q_iso_Q1
 
 #ifdef USE_FE_Q_iso_Q1
+#  undef FE_DEGREE
 #  define FE_DEGREE 2
 #  define N_Q_POINTS_1D FE_DEGREE * 2
 #else
-#  define FE_DEGREE 1
+#  ifndef FE_DEGREE
+#    define FE_DEGREE 1
+#  endif
 #  define N_Q_POINTS_1D FE_DEGREE + 1
 #endif
 


### PR DESCRIPTION
This is to be able to define different `FE_DEGREE`'s for each executable.