### PR TITLE
Move components and concentration flag offset to operators

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/driver.h
+++ b/applications/sintering/include/pf-applications/sintering/driver.h
@@ -933,12 +933,17 @@ namespace Sintering
           pcout << std::endl;
         }
 
+      // Offset of the order parameters
+      const unsigned int order_parameters_offset =
+        NonLinearOperatorTpl<dim, Number, VectorizedArrayType>::
+          op_components_offset;
+
       SinteringOperatorData<dim, VectorizedArrayType> sintering_data(
         kappa_c,
         kappa_p,
         mobility_provider,
         std::move(time_data),
-        FreeEnergyTpl<VectorizedArrayType>::op_components_offset);
+        order_parameters_offset);
 
       pcout << "Mobility type: "
             << (sintering_data.use_tensorial_mobility ? "tensorial" : "scalar")
@@ -961,8 +966,6 @@ namespace Sintering
                           sintering_data);
 
       // New grains can not appear in current sintering simulations
-      const unsigned int order_parameters_offset =
-        FreeEnergyTpl<VectorizedArrayType>::op_components_offset;
       const bool allow_new_grains = false;
       const bool do_timing        = true;
       const bool do_logging       = params.grain_tracker_data.verbosity >= 1;

--- a/applications/sintering/include/pf-applications/sintering/free_energy.h
+++ b/applications/sintering/include/pf-applications/sintering/free_energy.h
@@ -182,9 +182,7 @@ namespace Sintering
                                       EnergyEvaluation::first>>;
 
   public:
-    static constexpr unsigned int op_components_offset  = 2;
-    static constexpr bool         concentration_as_void = false;
-    static constexpr bool         save_gradients        = false;
+    static constexpr bool save_gradients = false;
 
     FreeEnergy(double A, double B)
       : A(A)

--- a/applications/sintering/include/pf-applications/sintering/operator_grain_growth.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_grain_growth.h
@@ -191,9 +191,7 @@ namespace Sintering
       Evaluation<any_energy_eval_of_v<Mask, EnergyEvaluation::zero>>;
 
   public:
-    static constexpr unsigned int op_components_offset  = 0;
-    static constexpr bool         concentration_as_void = false;
-    static constexpr bool         save_gradients        = false;
+    static constexpr bool save_gradients = false;
 
     GrainGrowthFreeEnergy(double A, double B)
       : A(A)
@@ -279,6 +277,9 @@ namespace Sintering
 
     using value_type  = Number;
     using vector_type = VectorType;
+
+    static constexpr unsigned int op_components_offset  = 0;
+    static constexpr bool         concentration_as_void = false;
 
     GrainGrowthOperator(
       const MatrixFree<dim, Number, VectorizedArrayType>      &matrix_free,

--- a/applications/sintering/include/pf-applications/sintering/operator_grand_potential_greenquist.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_grand_potential_greenquist.h
@@ -530,9 +530,7 @@ namespace Sintering
     };
 
   public:
-    static constexpr unsigned int op_components_offset  = 2;
-    static constexpr bool         concentration_as_void = true;
-    static constexpr bool         save_gradients        = false;
+    static constexpr bool save_gradients = false;
 
     GreenquistFreeEnergy(double A, double B)
     {
@@ -611,6 +609,9 @@ namespace Sintering
 
     using value_type  = Number;
     using vector_type = VectorType;
+
+    static constexpr unsigned int op_components_offset  = 2;
+    static constexpr bool         concentration_as_void = true;
 
     GreenquistGrandPotentialOperator(
       const MatrixFree<dim, Number, VectorizedArrayType>      &matrix_free,

--- a/applications/sintering/include/pf-applications/sintering/operator_sintering_base.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_sintering_base.h
@@ -39,6 +39,9 @@ namespace Sintering
     using value_type  = Number;
     using vector_type = VectorType;
 
+    static constexpr unsigned int op_components_offset  = 2;
+    static constexpr bool         concentration_as_void = false;
+
     SinteringOperatorBase(
       const MatrixFree<dim, Number, VectorizedArrayType>      &matrix_free,
       const AffineConstraints<Number>                         &constraints,

--- a/applications/sintering/include/pf-applications/sintering/runner.h
+++ b/applications/sintering/include/pf-applications/sintering/runner.h
@@ -79,9 +79,11 @@ namespace Sintering
 
     const std::string  mode(argv[1]);
     const unsigned int op_components_offset =
-      FreeEnergy<VectorizedArrayType>::op_components_offset;
+      NonLinearOperator<SINTERING_DIM, Number, VectorizedArrayType>::
+        op_components_offset;
     const bool concentration_as_void =
-      FreeEnergy<VectorizedArrayType>::concentration_as_void;
+      NonLinearOperator<SINTERING_DIM, Number, VectorizedArrayType>::
+        concentration_as_void;
 
     if (argc == 1 || mode == "--help")
       {

--- a/tests/include/pf-applications/tests/sintering_model.h
+++ b/tests/include/pf-applications/tests/sintering_model.h
@@ -69,7 +69,7 @@ namespace Test
           std::make_shared<ProviderAbstract>(1e-1, 1e-8, 1e1, 1e0, 1e1),
           TimeIntegratorData<Number>(std::make_unique<BDF1Scheme<Number>>(),
                                      /*dt=*/1e-5),
-          FreeEnergy::op_components_offset)
+          NonLinearOperator::op_components_offset)
       , solution_history(sintering_data.time_data.get_order() + 1)
       , advection_mechanism(enable_rbm,
                             /*mt=*/1.0,
@@ -141,7 +141,7 @@ namespace Test
         threshold_upper,
         buffer_distance_ratio,
         buffer_distance_fixed,
-        FreeEnergy::op_components_offset);
+        NonLinearOperator::op_components_offset);
 
       // External loading - not used at the moment
       auto body_force = [](const Point<dim, VectorizedArrayType> &p) {


### PR DESCRIPTION
This makes it easy to use the same free energy for operators with different layouts.