### PR TITLE
Sum only over active lanes

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/operator_base.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_base.h
@@ -907,11 +907,14 @@ namespace Sintering
                 }
             }
 
+          const unsigned int n_active_lanes =
+            this->matrix_free.n_active_entries_per_cell_batch(cell);
+
           for (unsigned int i = 0; i < quantities.size(); ++i)
             {
               const auto vals = fe_eval[i].integrate_value();
-              q_values[i] +=
-                std::accumulate(vals.begin(), vals.end(), Number(0));
+              for (unsigned int lane = 0; lane < n_active_lanes; ++lane)
+                q_values[i] += vals[lane];
             }
         }
 

--- a/applications/sintering/include/pf-applications/sintering/operator_base.h
+++ b/applications/sintering/include/pf-applications/sintering/operator_base.h
@@ -913,8 +913,9 @@ namespace Sintering
           for (unsigned int i = 0; i < quantities.size(); ++i)
             {
               const auto vals = fe_eval[i].integrate_value();
-              for (unsigned int lane = 0; lane < n_active_lanes; ++lane)
-                q_values[i] += vals[lane];
+              q_values[i] += std::accumulate(vals.begin(),
+                                             vals.begin() + n_active_lanes,
+                                             Number(0.));
             }
         }
 


### PR DESCRIPTION
To prevent `NaN`s contributing to the sum as recommended by the deal.II documentation (https://dealii.org/current/doxygen/deal.II/classFEEvaluationBase.html#ada523fada873497b00071b8b0bc35005).