### PR TITLE
Customize table precision for domain quantities

### DIFF
--- a/applications/sintering/include/pf-applications/sintering/driver.h
+++ b/applications/sintering/include/pf-applications/sintering/driver.h
@@ -3063,7 +3063,8 @@ namespace Sintering
                       const std::string q_label = generate_name(q_labels[j], i);
                       table.add_value(q_label, q_values[j]);
                       table.set_scientific(q_label, true);
-                      table.set_precision(q_label, 6);
+                      table.set_precision(q_label,
+                                          params.output_data.table_precision);
                     }
                 }
             }

--- a/applications/sintering/include/pf-applications/sintering/parameters.h
+++ b/applications/sintering/include/pf-applications/sintering/parameters.h
@@ -263,6 +263,7 @@ namespace Sintering
     double                gb_threshold     = 0.14;
     bool                  auto_control_box = false;
     double                box_rel_padding  = 0.05;
+    unsigned int          table_precision  = 6;
 
     std::vector<std::pair<Point<3>, Point<3>>> control_boxes;
 
@@ -958,6 +959,9 @@ namespace Sintering
         "BoxRelativePadding",
         output_data.box_rel_padding,
         "Auto control box padding relative to the packing size.");
+      prm.add_parameter("TablePrecision",
+                        output_data.table_precision,
+                        "Precision of table output.");
 
       prm.leave_subsection();
 


### PR DESCRIPTION
For some cases I need to increase significantly the output tolerance, e.g. when studying the convergence.